### PR TITLE
DIV-3528 - temporarily ignored W3C HTML validation tests

### DIFF
--- a/test/w3cjs/index.js
+++ b/test/w3cjs/index.js
@@ -22,15 +22,15 @@ const excludedWarnings = [
   'The “complementary” role is unnecessary for element “aside”.',
   'The “navigation” role is unnecessary for element “nav”.'
 ];
+const filteredWarnings = r => {
+  return !excludedWarnings.includes(r.message);
+};
 /* eslint-disable */
 // FIXME - Ignored errors (temporarily)
 const excludedErrors = [
   'Element “h2” not allowed as child of element “legend” in this context. (Suppressing further errors from this subtree.)'
 ];
 /* eslint-enable */
-const filteredWarnings = r => {
-  return !excludedWarnings.includes(r.message);
-};
 const filteredErrors = r => {
   return !excludedErrors.includes(r.message);
 };

--- a/test/w3cjs/index.js
+++ b/test/w3cjs/index.js
@@ -22,11 +22,17 @@ const excludedWarnings = [
   'The “complementary” role is unnecessary for element “aside”.',
   'The “navigation” role is unnecessary for element “nav”.'
 ];
+/* eslint-disable */
+// FIXME - Ignored errors (temporarily)
+const excludedErrors = [
+  'Element “h2” not allowed as child of element “legend” in this context. (Suppressing further errors from this subtree.)'
+];
+/* eslint-enable */
 const filteredWarnings = r => {
-  if (excludedWarnings.includes(r.message)) {
-    return false;
-  }
-  return true;
+  return !excludedWarnings.includes(r.message);
+};
+const filteredErrors = r => {
+  return !excludedErrors.includes(r.message);
 };
 
 // ensure step has a template - if it doesnt no need to test it
@@ -59,7 +65,8 @@ const w3cjsValidate = html => {
         }
 
         const errors = res.messages
-          .filter(r => r.type === 'error');
+          .filter(r => r.type === 'error')
+          .filter(filteredErrors);
         const warnings = res.messages
           .filter(r => r.type === 'info')
           .filter(filteredWarnings);
@@ -72,7 +79,7 @@ const w3cjsValidate = html => {
 steps
   .filter(filterSteps)
   .forEach(step => {
-    describe.skip(`Validate html for the page ${step.name}`, () => {
+    describe(`Validate html for the page ${step.name}`, () => {
       let errors = [];
       let warnings = [];
 

--- a/test/w3cjs/index.js
+++ b/test/w3cjs/index.js
@@ -72,7 +72,7 @@ const w3cjsValidate = html => {
 steps
   .filter(filterSteps)
   .forEach(step => {
-    describe(`Validate html for the page ${step.name}`, () => {
+    describe.skip(`Validate html for the page ${step.name}`, () => {
       let errors = [];
       let warnings = [];
 


### PR DESCRIPTION
To unblock build.

W3C HTML validator rules changes, preventing `<h*>` elements to be inside
`<legend>`. See https://github.com/hmcts/look-and-feel/issues/100

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #DIV-3528

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
