### PR TITLE
Change additional_host_name to be something other than the default

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -4,7 +4,7 @@ vault_section = "preprod"
 packages_environment = "preprod"
 packages_version = "3.0.0"
 
-additional_host_name = "div-rfe-aat.service.core-compute-aat.internal"
+additional_host_name = "div-rfe.aat.platform.hmcts.net"
 http_proxy = ""
 
 idam_authentication_web_url = "https://idam.preprod.ccidam.reform.hmcts.net"


### PR DESCRIPTION
# Description
We get a "Too many (2) hostnames in the default DNS zone. Limit is 1"
error that might be due to this (duplicate hostname entries)

We changed this back in October 29 but we think it never took effect at the time and only surfaced last Friday when we deleted the env and recreated it

Fixes # (issue)

##

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
