### PR TITLE
DIV-3766 - remove "idam-authentication" (web app) health check

### DIFF
--- a/middleware/healthcheck.js
+++ b/middleware/healthcheck.js
@@ -22,18 +22,10 @@ const checks = () => {
           return false;
         });
     }),
-    'idam-authentication': healthcheck.web(config.services.idam.authenticationHealth, {
+    'idam-api': healthcheck.web(config.services.idam.apiHealth, {
       callback: (error, res) => { // eslint-disable-line id-blacklist
         if (error) {
-          logger.error(`Health check failed on idam-authentication: ${error}`);
-        }
-        return !error && res.status === OK ? outputs.up() : outputs.down(error);
-      }
-    }, options),
-    'idam-app': healthcheck.web(config.services.idam.apiHealth, {
-      callback: (error, res) => { // eslint-disable-line id-blacklist
-        if (error) {
-          logger.error(`Health check failed on idam-app: ${error}`);
+          logger.error(`Health check failed on idam-api: ${error}`);
         }
         return !error && res.status === OK ? outputs.up() : outputs.down(error);
       }

--- a/test/unit/middleware/healthcheck.test.js
+++ b/test/unit/middleware/healthcheck.test.js
@@ -63,22 +63,22 @@ describe(modulePath, () => {
       .then(done, done);
   });
 
-  it('throws an error if healthcheck fails for idam-authentication', () => {
+  it.skip('throws an error if healthcheck fails for idam-web-app', () => {
     setupHealthChecks(app);
 
     const idamCallback = healthcheck.web.firstCall.args[1].callback;
     idamCallback('error');
 
-    sinon.assert.calledWith(logger.error, 'Health check failed on idam-authentication: error');
+    sinon.assert.calledWith(logger.error, 'Health check failed on idam-web-app: error');
   });
 
-  it('throws an error if healthcheck fails for idam-app', () => {
+  it('throws an error if healthcheck fails for idam-api', () => {
     setupHealthChecks(app);
 
-    const idamCallback = healthcheck.web.secondCall.args[1].callback;
+    const idamCallback = healthcheck.web.firstCall.args[1].callback;
     idamCallback('error');
 
-    sinon.assert.calledWith(logger.error, 'Health check failed on idam-app: error');
+    sinon.assert.calledWith(logger.error, 'Health check failed on idam-api: error');
   });
 
   it('returns up if no error passed', () => {
@@ -90,10 +90,10 @@ describe(modulePath, () => {
     sinon.assert.called(outputs.up);
   });
 
-  it('throws an error if healthcheck fails for idam-app', () => {
+  it('throws an error if healthcheck fails for idam-api', () => {
     setupHealthChecks(app);
 
-    const idamCallback = healthcheck.web.secondCall.args[1].callback;
+    const idamCallback = healthcheck.web.firstCall.args[1].callback;
     idamCallback(null, res);
 
     sinon.assert.called(outputs.up);


### PR DESCRIPTION


# Description
Recently, DevOps have introduced a proxy requirement for this endpoint (ticket RDO-3077)

The healthcheck module currently doesn't support a proxy, so we're removing this temporarily.

Fixes #DIV-3766

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
