### PR TITLE
Move idam auth to after assets

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,11 +25,6 @@ setupRateLimiter(app);
 // Parsing cookies
 app.use(cookieParser());
 
-// Get user details from idam, sets req.idam.userDetails
-app.use(idam.userDetails());
-
-app.use(setLocals.idamLoggedin);
-
 lookAndFeel.configure(app, {
   baseUrl: '/',
   express: {
@@ -79,6 +74,11 @@ app.use('/public', (req, res) => {
 app.use('/images', (req, res) => {
   res.redirect(`/assets/images${req.path}`, '301');
 });
+
+// Get user details from idam, sets req.idam.userDetails
+app.use(idam.userDetails());
+
+app.use(setLocals.idamLoggedin);
 
 app.set('trust proxy', 1);
 


### PR DESCRIPTION
# Description

[DIV-3646 - Slow pages loads could be result of getting IDAM credentials on every request ( including assets )](https://tools.hmcts.net/jira/browse/DIV-3646)

Move IDAM auth after assets in effort to speed up application.