### PR TITLE
Enable CSRF and fix local mocks for local testing

### DIFF
--- a/app.js
+++ b/app.js
@@ -102,7 +102,8 @@ onePerPage.journey(app, {
     }
   },
   timeoutDelay: config.journey.timeoutDelay,
-  i18n: { filters: getFilters() }
+  i18n: { filters: getFilters() },
+  useCsrfToken: true
 });
 
 app.use(logging.Express.accessLogger());

--- a/mocks/services/case-orchestration/retrieve-aos-case/mock-2yr-separation-case.json
+++ b/mocks/services/case-orchestration/retrieve-aos-case/mock-2yr-separation-case.json
@@ -213,7 +213,7 @@
     "courts": "northWest",
     "confirmPrayer": "Yes",
     "marriageCertificateFiles": [],
-    "respEmailAddress": "divdemores@mailinator.com",
+    "respEmailAddress": "user@email.com",
     "d8": [
       {
         "createdBy": 0,

--- a/mocks/services/case-orchestration/retrieve-aos-case/mock-5yr-separation-case.json
+++ b/mocks/services/case-orchestration/retrieve-aos-case/mock-5yr-separation-case.json
@@ -213,7 +213,7 @@
     "courts": "northWest",
     "confirmPrayer": "Yes",
     "marriageCertificateFiles": [],
-    "respEmailAddress": "divdemores@mailinator.com",
+    "respEmailAddress": "user@email.com",
     "d8": [
       {
         "createdBy": 0,

--- a/mocks/services/case-orchestration/retrieve-aos-case/mock-adultery-case.json
+++ b/mocks/services/case-orchestration/retrieve-aos-case/mock-adultery-case.json
@@ -213,7 +213,7 @@
     "courts": "northWest",
     "confirmPrayer": "Yes",
     "marriageCertificateFiles": [],
-    "respEmailAddress": "divdemores@mailinator.com",
+    "respEmailAddress": "user@email.com",
     "d8": [
       {
         "createdBy": 0,

--- a/mocks/services/case-orchestration/retrieve-aos-case/mock-petitioner-redirect.json
+++ b/mocks/services/case-orchestration/retrieve-aos-case/mock-petitioner-redirect.json
@@ -213,7 +213,7 @@
     "courts": "northWest",
     "confirmPrayer": "Yes",
     "marriageCertificateFiles": [],
-    "respEmailAddress": "divdemores@mailinator.com",
+    "respEmailAddress": "user@email.com",
     "d8": [
       {
         "createdBy": 0,

--- a/mocks/services/case-orchestration/retrieve-aos-case/mock-started-response.json
+++ b/mocks/services/case-orchestration/retrieve-aos-case/mock-started-response.json
@@ -211,7 +211,7 @@
       }
     },
     "courts": "serviceCentre",
-    "respEmailAddress": "divdemores@mailinator.com",
+    "respEmailAddress": "user@email.com",
     "confirmPrayer": "Yes",
     "payment": {
       "PaymentChannel": "card",

--- a/steps/check-your-answers/CheckYourAnswers.html
+++ b/steps/check-your-answers/CheckYourAnswers.html
@@ -60,6 +60,8 @@
     </div>
 
     <br>
+    
+    <input type="hidden" name="_csrf" value="{{csurfCsrfToken}}">
 {%- endblock %}
 
 {% block after_form %}


### PR DESCRIPTION
# Description

[DIV-3861](https://tools.hmcts.net/jira/browse/DIV-3861)

CSRF is currently not active on RFE. It is a feature in OPP and Look and Feel and just needs to be enabled.

Also local testing fails because mocked respondent email address does not match the mock IDAM user email in certain scenarios. To fix this, modified the mock respondent email addresses to match the IDAM mock user email.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests pass. Manual test pass, manually modifying the csrf fails the page as expected, so all good thus far.

**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
