### PR TITLE
DIV-3830: Changed simulate email address with valid gmail for int tests

### DIFF
--- a/test/e2e/helpers/idamHelper.js
+++ b/test/e2e/helpers/idamHelper.js
@@ -22,7 +22,7 @@ class IdamHelper extends Helper {
       length: 16,
       charset: 'numeric'
     });
-    const emailName = `hmcts.divorce.reform+automatedtest-${randomString}`;
+    const emailName = `hmcts.divorce.reform+rfe-automatedtest-${randomString}`;
     const testEmail = `${emailName}@gmail.com`;
     const testPassword = randomstring.generate(9);
 

--- a/test/e2e/helpers/idamHelper.js
+++ b/test/e2e/helpers/idamHelper.js
@@ -22,8 +22,8 @@ class IdamHelper extends Helper {
       length: 16,
       charset: 'numeric'
     });
-    const emailName = `simulate-delivered-${randomString}`;
-    const testEmail = `${emailName}@notifications.service.gov.uk`;
+    const emailName = `hmcts.divorce.reform+automatedtest-${randomString}`;
+    const testEmail = `${emailName}@gmail.com`;
     const testPassword = randomstring.generate(9);
 
     idamArgs.testEmail = testEmail;

--- a/test/unit/steps/done.test.js
+++ b/test/unit/steps/done.test.js
@@ -348,7 +348,7 @@ describe(modulePath, () => {
         divorceCenterEmail: 'eastmidlandsdivorce@hmcts.gsi.gov.uk',
         divorceCenterPhoneNumber: '0300 303 0642',
         originalPetition: {
-          respEmailAddress: 'test@test.com'
+          respEmailAddress: 'simulate-delivered@notifications.service.gov.uk'
         }
       };
       return content(


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-3830

Replace ‘email@email.com’ from emails from integration tests as it is spamming notification service when we run integration tests. 
Created new HMCTS Divorce gmail account for testing with unique users