### PR TITLE
[PREVIEW] DIV-3853 Apply infra for app insights config

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,6 +39,7 @@ module "frontend" {
   common_tags                   = "${var.common_tags}"
   asp_name                      = "${local.asp_name}"
   asp_rg                        = "${local.asp_rg}"
+  appinsights_instrumentation_key = "${var.appinsights_instrumentation_key}"
 
   app_settings = {
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -14,6 +14,8 @@ locals {
   div_fps_url              = "http://div-fps-${local.local_env}.service.core-compute-${local.local_env}.internal"
   asp_name = "${var.env == "prod" ? "div-rfe-prod" : "${var.raw_product}-${var.env}"}"
   asp_rg = "${var.env == "prod" ? "div-rfe-prod" : "${var.raw_product}-${var.env}"}"
+  appinsights_name           = "${var.env == "preview" ? "${var.product}-${var.reform_service_name}-appinsights-${var.env}" : "${var.product}-${var.env}"}"
+  appinsights_resource_group = "${var.env == "preview" ? "${var.product}-${var.reform_service_name}-${var.env}" : "${var.product}-${var.env}"}"
 }
 
 module "redis-cache" {
@@ -40,6 +42,7 @@ module "frontend" {
   asp_name                      = "${local.asp_name}"
   asp_rg                        = "${local.asp_rg}"
   appinsights_instrumentation_key = "${var.appinsights_instrumentation_key}"
+
 
   app_settings = {
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -194,3 +194,8 @@ variable "website_local_cache_sizeinmb" {
   type = "string"
   default = "0"
 }
+
+variable "appinsights_instrumentation_key" {
+  description = "Instrumentation key of the App Insights instance this webapp should use. Module will create own App Insights resource if this is not provided"
+  default     = ""
+}


### PR DESCRIPTION
# Description

Fetch App Insights instrumentation key from Key Vault secrets instead of using App Service environment variables. This process is managed by [CNP module](https://github.com/hmcts/cnp-module-webapp/blob/master/main.tf#L66) for deploying into Azure.

Fixes # DIV-3853

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing for checking that PR in PREVIEW is pointing to AAT App Insights.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
