### PR TITLE
Change deprecated RespDefendsDivorce to te RespWillDefendDivorce field

### DIFF
--- a/mocks/services/case-orchestration/retrieve-aos-case/case-progressed/awaiting-answer.json
+++ b/mocks/services/case-orchestration/retrieve-aos-case/case-progressed/awaiting-answer.json
@@ -198,7 +198,7 @@
     "issueDate": "2018-10-18T00:00:00.000+0000",
     "respConfirmReadPetition": "Yes",
     "respJurisdictionAgree": "Yes",
-    "respDefendsDivorce": "Yes",
+    "respWillDefendDivorce": "Yes",
     "respLegalProceedingsExist": "No",
     "respLegalProceedingsDescription": "some of personnel once",
     "respEmailAddress": "vivdivres@mailinator.com",

--- a/mocks/services/case-orchestration/retrieve-aos-case/case-progressed/defended.json
+++ b/mocks/services/case-orchestration/retrieve-aos-case/case-progressed/defended.json
@@ -198,7 +198,7 @@
     "issueDate": "2018-10-18T00:00:00.000+0000",
     "respConfirmReadPetition": "Yes",
     "respJurisdictionAgree": "Yes",
-    "respDefendsDivorce": "Yes",
+    "respWillDefendDivorce": "Yes",
     "respLegalProceedingsExist": "No",
     "respLegalProceedingsDescription": "some of personnel once",
     "respEmailAddress": "vivdivres@mailinator.com",

--- a/mocks/services/case-orchestration/retrieve-aos-case/case-progressed/no-aos.json
+++ b/mocks/services/case-orchestration/retrieve-aos-case/case-progressed/no-aos.json
@@ -198,7 +198,7 @@
     "issueDate": "2018-10-18T00:00:00.000+0000",
     "respConfirmReadPetition": "Yes",
     "respJurisdictionAgree": "Yes",
-    "respDefendsDivorce": null,
+    "respWillDefendDivorce": null,
     "respLegalProceedingsExist": "No",
     "respLegalProceedingsDescription": "some of personnel once",
     "respEmailAddress": "vivdivres@mailinator.com",

--- a/mocks/services/case-orchestration/retrieve-aos-case/case-progressed/not-defended.json
+++ b/mocks/services/case-orchestration/retrieve-aos-case/case-progressed/not-defended.json
@@ -209,7 +209,7 @@
     "issueDate": "2018-10-18T00:00:00.000+0000",
     "respConfirmReadPetition": "Yes",
     "respJurisdictionAgree": "Yes",
-    "respDefendsDivorce": "No",
+    "respWillDefendDivorce": "No",
     "respLegalProceedingsExist": "No",
     "respLegalProceedingsDescription": "some of personnel once",
     "respEmailAddress": "vivdivres@mailinator.com",

--- a/steps/respondent/consent-decree/ConsentDecree.step.js
+++ b/steps/respondent/consent-decree/ConsentDecree.step.js
@@ -32,10 +32,10 @@ class ConsentDecree extends Question {
 
   values() {
     const respAdmitOrConsentToFact = this.fields.response.consentDecree.value;
-    const respDefendsDivorce = this.fields.response.willDefend.value === this.const.yes ? this.const.yes : this.const.no;
+    const respWillDefendDivorce = this.fields.response.willDefend.value === this.const.yes ? this.const.yes : this.const.no;
     return {
       respAdmitOrConsentToFact,
-      respDefendsDivorce
+      respWillDefendDivorce
     };
   }
 

--- a/steps/respondent/progress-bar/ProgressBar.step.js
+++ b/steps/respondent/progress-bar/ProgressBar.step.js
@@ -76,11 +76,11 @@ class ProgressBar extends Interstitial {
   }
 
   progressedNoAos(caseState) {
-    return this.caseBeyondAos(caseState) && !this.session.originalPetition.respDefendsDivorce;
+    return this.caseBeyondAos(caseState) && !this.session.originalPetition.respWillDefendDivorce;
   }
 
   progressedUndefended(caseState) {
-    return this.caseBeyondAos(caseState) && this.session.originalPetition.respDefendsDivorce === values.no;
+    return this.caseBeyondAos(caseState) && this.session.originalPetition.respWillDefendDivorce === values.no;
   }
 
   awaitingAnswer(caseState) {
@@ -106,7 +106,7 @@ class ProgressBar extends Interstitial {
   }
 
   get isDefending() {
-    return this.session.originalPetition.respDefendsDivorce === values.yes;
+    return this.session.originalPetition.respWillDefendDivorce === values.yes;
   }
 
   get middleware() {

--- a/test/unit/services/googleAnalytics.test.js
+++ b/test/unit/services/googleAnalytics.test.js
@@ -17,7 +17,7 @@ describe('Google analytics', () => {
     const session = {
       caseState: 'AwaitingLegalAdvisorReferral',
       originalPetition: {
-        respDefendsDivorce: null
+        respWillDefendDivorce: null
       }
     };
     const googleAnalyticsId = 'google-analytics-id';

--- a/test/unit/steps/respondent/consentDecree.test.js
+++ b/test/unit/steps/respondent/consentDecree.test.js
@@ -127,7 +127,7 @@ describe(modulePath, () => {
     expect(values)
       .to
       .have
-      .property('respDefendsDivorce', answers.no);
+      .property('respWillDefendDivorce', answers.no);
   });
 
   it('sets value for consent and defence based on form fields', () => {
@@ -158,7 +158,7 @@ describe(modulePath, () => {
     expect(values)
       .to
       .have
-      .property('respDefendsDivorce', answers.yes);
+      .property('respWillDefendDivorce', answers.yes);
   });
 
   it('applies the correct answer object given consent', () => {

--- a/test/unit/steps/respondent/progressBar.test.js
+++ b/test/unit/steps/respondent/progressBar.test.js
@@ -39,7 +39,7 @@ describe(modulePath, () => {
     const session = {
       caseState: 'AwaitingLegalAdvisorReferral',
       originalPetition: {
-        respDefendsDivorce: null
+        respWillDefendDivorce: null
       }
     };
 
@@ -54,7 +54,7 @@ describe(modulePath, () => {
     const session = {
       caseState: 'AwaitingLegalAdvisorReferral',
       originalPetition: {
-        respDefendsDivorce: 'No'
+        respWillDefendDivorce: 'No'
       }
     };
 
@@ -68,7 +68,7 @@ describe(modulePath, () => {
     const session = {
       caseState: 'AosSubmittedAwaitingAnswer',
       originalPetition: {
-        respDefendsDivorce: 'Yes'
+        respWillDefendDivorce: 'Yes'
       }
     };
 
@@ -86,7 +86,7 @@ describe(modulePath, () => {
     const session = {
       caseState: 'DefendedDivorce',
       originalPetition: {
-        respDefendsDivorce: 'Yes'
+        respWillDefendDivorce: 'Yes'
       }
     };
 
@@ -103,7 +103,7 @@ describe(modulePath, () => {
     const session = {
       caseState: 'AwaitingReissue',
       originalPetition: {
-        respDefendsDivorce: 'Yes'
+        respWillDefendDivorce: 'Yes'
       }
     };
 
@@ -116,7 +116,7 @@ describe(modulePath, () => {
     const basicSession = {
       caseState: CaseStates.AosSubmittedAwaitingAnswer,
       originalPetition: {
-        respDefendsDivorce: undefined
+        respWillDefendDivorce: undefined
       }
     };
 


### PR DESCRIPTION
# Description

[DIV-4267](https://tools.hmcts.net/jira/browse/DIV-4267)

RespDefendsDivorce is an old CCD field that should no longer be used. However it is currently used in the Separation-2-Year Journey. This PR replaces it with the newer RespWillDefendDivorce field