### PR TITLE
Sonar Duplicate checks excluded

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,6 +7,4 @@ sonar.tests=test
 sonar.language=js
 sonar.dynamicAnalysis=reuseReports
 sonar.exclusions=node_modules/**/*, test/**/*, assets/**/*, config/**/*, infrastructure/**/*, resources/**/*, views/**/*, coverage/**/*, app.js, server.js
-
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.cpd.exclusions=steps/co-respondent

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,6 +7,7 @@ sonar.tests=test
 sonar.language=js
 sonar.dynamicAnalysis=reuseReports
 sonar.exclusions=node_modules/**/*, test/**/*, assets/**/*, config/**/*, infrastructure/**/*, resources/**/*, views/**/*, coverage/**/*, app.js, server.js
+
 sonar.cpd.exclusions=steps/co-respondent/**/*, steps/respondent/**/*
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,3 +9,4 @@ sonar.dynamicAnalysis=reuseReports
 sonar.exclusions=node_modules/**/*, test/**/*, assets/**/*, config/**/*, infrastructure/**/*, resources/**/*, views/**/*, coverage/**/*, app.js, server.js
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+sonar.cpd.exclusions=steps/co-respondent

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,4 +7,6 @@ sonar.tests=test
 sonar.language=js
 sonar.dynamicAnalysis=reuseReports
 sonar.exclusions=node_modules/**/*, test/**/*, assets/**/*, config/**/*, infrastructure/**/*, resources/**/*, views/**/*, coverage/**/*, app.js, server.js
+
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+sonar.cpd.exclusions=steps/co-respondent/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,6 +7,6 @@ sonar.tests=test
 sonar.language=js
 sonar.dynamicAnalysis=reuseReports
 sonar.exclusions=node_modules/**/*, test/**/*, assets/**/*, config/**/*, infrastructure/**/*, resources/**/*, views/**/*, coverage/**/*, app.js, server.js
+sonar.cpd.exclusions=steps/co-respondent/**/*, steps/respondent/**/*
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.cpd.exclusions=steps/co-respondent/*


### PR DESCRIPTION
Excluding Duplicate checks as respondent and co-respondent have similar data
Sonar scan is failing on master rfe but on AKS it is successful.