### PR TITLE
Desertion agreement details added in mini-petition

### DIFF
--- a/steps/respondent/review-application/ReviewApplication.content.json
+++ b/steps/respondent/review-application/ReviewApplication.content.json
@@ -119,6 +119,7 @@
     "reasonForDivorceSeparationFiveYears2DatesRecent": "The most recent date is considered legally to be the date of separation.",
     "reasonForDivorceSeparationTwoYears2DatesRecent": "The most recent date is considered legally to be the date of separation.",
     "reasonForDivorceDesertion": "The applicant has given the date of desertion as ",
+    "reasonForDivorceDesertionAgreed": "The applicant stated that the respondent left without their agreement.",
     "descriptionOfDesertion": "Description of the desertion",
     "reasonForDivorceDesertionBrokenDown": "The respondent has deserted the applicant for a continuous period of at least two years immediately preceding the presentation of this application.",
     "reasonForDivorceDesertionStatement": "This is supported by the following statement from the applicant.",

--- a/steps/respondent/review-application/ReviewApplication.html
+++ b/steps/respondent/review-application/ReviewApplication.html
@@ -322,9 +322,12 @@
   {% endif %}
 
   {% if session.originalPetition.reasonForDivorce == "desertion" %}
-    <p class="text">{{ content.reasonForDivorceDesertionBrokenDown }}
+    <p class="text">{{ content.reasonForDivorceDesertionBrokenDown }}</p>
     <p class="text">{{ content.reasonForDivorceDesertionStatement }}</p>
     <p class="text">{{ content.reasonForDivorceDesertion }} {{ session.originalPetition.reasonForDivorceDesertionDate | date }}.</p>
+    {% if session.originalPetition.reasonForDivorceDesertionAgreed == "Yes" %}
+       <p class="text">{{ content.reasonForDivorceDesertionAgreed }}</p>
+    {% endif %}
     <p class="heading-small">{{ content.descriptionOfDesertion }}</p>
     <p class="text">"{{ session.originalPetition.reasonForDivorceDesertionDetails }}"</p>
   {% endif %}

--- a/test/unit/steps/respondent/reviewApplication.test.js
+++ b/test/unit/steps/respondent/reviewApplication.test.js
@@ -341,6 +341,7 @@ describe(modulePath, () => {
         'reasonForDivorceSeparationFiveYears',
         'reasonForDivorceSeparationFiveYearsBrokenDown',
         'reasonForDivorceDesertion',
+        'reasonForDivorceDesertionAgreed',
         'descriptionOfAdultery',
         'descriptionOfBehaviour',
         'descriptionOfDesertion',
@@ -762,13 +763,15 @@ describe(modulePath, () => {
         const session = {
           originalPetition: {
             jurisdictionConnection: {},
-            reasonForDivorce: 'desertion'
+            reasonForDivorce: 'desertion',
+            reasonForDivorceDesertionAgreed: 'Yes'
           }
         };
         const specificContent = [
           'reasonForDivorceDesertionBrokenDown',
           'reasonForDivorceDesertion',
-          'reasonForDivorceDesertionStatement'
+          'reasonForDivorceDesertionStatement',
+          'reasonForDivorceDesertionAgreed'
         ];
         return content(ReviewApplication, session, { specificContent });
       });


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-4359

If the field D8ReasonForDivorceDesertionAgreed = 'Yes', then additional text ("The applicant stated that the respondent left without their agreement.") should show in the mini-petition.