### PR TITLE
DIV-4665 - set NODE_ENV in master pipeline for AAT testes

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -53,6 +53,11 @@ withPipeline("nodejs", product, component) {
     sh 'printenv'
   }
 
+  before('functionalTest:aat') {
+    env.NODE_ENV= 'ci'
+    sh 'printenv'
+  }
+
   after('functionalTest:preview') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**/*'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'

--- a/test/e2e/helpers/idamHelper.js
+++ b/test/e2e/helpers/idamHelper.js
@@ -56,7 +56,7 @@ class IdamHelper extends Helper {
           null,
           'idam_error',
           'Unable to create IDAM test user/token',
-          error
+          error.message
         );
         throw error;
       });


### PR DESCRIPTION
# Description

As NODE_ENV=ci was moved from `after('test')` to before every functional stage, this was missed

Fixes #DIV-4665

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
