### PR TITLE
Redirect to capture pin page when case state is aos awaiting

### DIFF
--- a/middleware/petitionMiddleware.js
+++ b/middleware/petitionMiddleware.js
@@ -60,6 +60,10 @@ const loadMiniPetition = (req, res, next) => {
         if (idamUserIsCorespondent) {
           return res.redirect(findCoRespPath(coRespAnswers, caseState));
         }
+        if (caseState === config.caseStates.AosAwaiting) {
+          logger.infoWithReq(req, 'case_aos_awaiting', 'Case is awaiting, redirecting to capture case and pin page');
+          return res.redirect(CaptureCaseAndPin.path);
+        }
         if (caseState !== config.caseStates.AosStarted) {
           logger.infoWithReq(req, 'case_not_started', 'Case not started, redirecting to progress bar page');
           return res.redirect(ProgressBar.path);

--- a/test/unit/middleware/petitionMiddleware.test.js
+++ b/test/unit/middleware/petitionMiddleware.test.js
@@ -45,6 +45,46 @@ describe(modulePath, () => {
       .then(done, done);
   });
 
+  it('redirects to capture case and pin if case found, state: AosAwaiting', done => {
+    // given
+    const req = {
+      cookies: { '__auth-token': 'test' },
+      get: sinon.stub(),
+      session: {}
+    };
+    const res = {
+      redirect: sinon.spy()
+    };
+    const next = sinon.stub();
+
+    const response = {
+      statusCode: 200,
+      body: {
+        state: 'AosAwaiting',
+        caseId: 1234,
+        data: { // eslint-disable-line id-blacklist
+          marriageIsSameSexCouple: 'No',
+          divorceWho: 'husband',
+          courts: 'eastMidlands',
+          court: {
+            eastMidlands: {
+              divorceCentre: 'East Midlands Regional Divorce Centre'
+            }
+          }
+        }
+      }
+    };
+
+    sinon.stub(caseOrchestration, 'getPetition')
+      .resolves(response);
+
+    // when
+    petitionMiddleware(req, res, next)
+      .then(() => {
+        expect(res.redirect.withArgs(CaptureCaseAndPin.path).calledOnce).to.be.true;
+      })
+      .then(done, done);
+  });
 
   it('should redirect to Co-respondent respond page if user is Co-respondent', done => {
     // given
@@ -199,6 +239,7 @@ describe(modulePath, () => {
       body: {
         state: 'AosStarted',
         caseId: 1234,
+        caseReference: 'LV17D80999',
         data: { // eslint-disable-line id-blacklist
           marriageIsSameSexCouple: 'No',
           divorceWho: 'husband',


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-4474

When the case is in aos awaiting state  if case is found associated with resp email address, we should redirect to Capture case and pin page