### PR TITLE
Co-respondent can see the details of the DN approval in their account

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -170,8 +170,8 @@ document:
   filesWhiteList:
     coRespondent:
     - 'd8petition'
-    - 'respondentAnswers'
     respondent:
+    - 'certificateOfEntitlement'
     - 'd8petition'
     - 'respondentAnswers'
 

--- a/mocks/services/case-orchestration/retrieve-aos-case/GET_Authorization=Bearer coRespAwaitingPronouncementHearingDataFuture.mock
+++ b/mocks/services/case-orchestration/retrieve-aos-case/GET_Authorization=Bearer coRespAwaitingPronouncementHearingDataFuture.mock
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+
+#import './mock-coRespAwaitingPronouncementHearingDataFuture.json';

--- a/mocks/services/case-orchestration/retrieve-aos-case/mock-coRespAwaitingPronouncementHearingDataFuture.json
+++ b/mocks/services/case-orchestration/retrieve-aos-case/mock-coRespAwaitingPronouncementHearingDataFuture.json
@@ -1,0 +1,308 @@
+{
+  "caseId": "1550848268807298",
+  "courts": "serviceCentre",
+  "state": "AwaitingPronouncement",
+  "data": {
+    "hearingDate": ["3000-01-01T00:00:00.000+0000"],
+    "costsClaimGranted": "Yes",
+    "whoPaysCosts": "respondent and correspondent",
+    "expires": 0,
+    "caseReference": "LV17D80100",
+    "screenHasMarriageBroken": "Yes",
+    "screenHasRespondentAddress": "Yes",
+    "screenHasMarriageCert": "Yes",
+    "helpWithFeesNeedHelp": "No",
+    "divorceWho": "husband",
+    "marriageIsSameSexCouple": "No",
+    "marriageDateDay": 9,
+    "marriageDateMonth": 9,
+    "marriageDateYear": 1979,
+    "marriageDate": "1979-09-09T00:00:00.000+0000",
+    "marriageCanDivorce": "true",
+    "marriedInUk": "Yes",
+    "placeOfMarriage": "London",
+    "jurisdictionConnection": [
+      "A",
+      "C"
+    ],
+    "connections": {
+      "A": "The Petitioner and the Respondent are habitually resident in England and Wales",
+      "B": null,
+      "C": "The Respondent is habitually resident in England and Wales",
+      "D": null,
+      "E": null,
+      "F": null,
+      "G": null
+    },
+    "jurisdictionPetitionerResidence": "Yes",
+    "jurisdictionRespondentResidence": "Yes",
+    "jurisdictionConfidentLegal": "Yes",
+    "petitionerContactDetailsConfidential": "share",
+    "petitionerFirstName": "Paloma",
+    "petitionerLastName": "Acosta",
+    "respondentFirstName": "Henry",
+    "respondentLastName": "Morrison",
+    "marriagePetitionerName": "Barbara Howell",
+    "marriageRespondentName": "Mufutau Pratt",
+    "petitionerNameDifferentToMarriageCertificate": "No",
+    "petitionerEmail": "nabyg@mailinator.com",
+    "petitionerHomeAddress": {
+      "addressType": "postcode",
+      "postcode": "E15 3DT",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": "true",
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": "false",
+      "url": null,
+      "address": [
+        "16 Chaplin Road",
+        "London",
+        "E15 3DT"
+      ]
+    },
+    "petitionerCorrespondenceUseHomeAddress": "Yes",
+    "petitionerCorrespondenceAddress": {
+      "addressType": "postcode",
+      "postcode": "E15 3DT",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": "true",
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": "false",
+      "url": null,
+      "address": [
+        "16 Chaplin Road",
+        "London",
+        "E15 3DT"
+      ]
+    },
+    "livingArrangementsLiveTogether": "Yes",
+    "respondentHomeAddress": {
+      "addressType": "postcode",
+      "postcode": "E15 3DT",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": "true",
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": "false",
+      "url": null,
+      "address": [
+        "16 Chaplin Road",
+        "London",
+        "E15 3DT"
+      ]
+    },
+    "respondentCorrespondenceUseHomeAddress": "Yes",
+    "respondentCorrespondenceAddress": {
+      "addressType": "postcode",
+      "postcode": "E15 3DT",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": "true",
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": "false",
+      "url": null,
+      "address": [
+        "16 Chaplin Road",
+        "London",
+        "E15 3DT"
+      ]
+    },
+    "reasonForDivorce": "adultery",
+    "reasonForDivorceHasMarriageDate": "true",
+    "reasonForDivorceShowAdultery": "true",
+    "reasonForDivorceShowUnreasonableBehaviour": "true",
+    "reasonForDivorceShowTwoYearsSeparation": "true",
+    "reasonForDivorceShowFiveYearsSeparation": "true",
+    "reasonForDivorceShowDesertion": "true",
+    "reasonForDivorceLimitReasons": "false",
+    "reasonForDivorceEnableAdultery": "true",
+    "reasonForDivorceAdulteryWishToName": "Yes",
+    "reasonForDivorceAdultery3rdPartyFirstName": "Baxter",
+    "reasonForDivorceAdultery3rdPartyLastName": "Gill",
+    "reasonForDivorceAdultery3rdAddress": {
+      "addressType": "postcode",
+      "postcode": "E15 4PT",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": "true",
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": "false",
+      "url": null,
+      "address": [
+        "80 West Ham Lane",
+        "London",
+        "E15 4PT"
+      ]
+    },
+    "reasonForDivorceAdulteryKnowWhere": "Yes",
+    "reasonForDivorceAdulteryKnowWhen": "Yes",
+    "reasonForDivorceAdulteryDetails": "Molestias nostrum es",
+    "reasonForDivorceAdulteryWhenDetails": "Ex voluptate enim co",
+    "reasonForDivorceAdulteryWhereDetails": "Ut consequatur sed",
+    "legalProceedings": "No",
+    "financialOrder": "No",
+    "claimsCosts": "No",
+    "claimsCostsFrom": [
+      "respondent",
+      "correspondent"
+    ],
+    "reasonForDivorceAdulteryIsNamed": "Yes",
+    "claimsCostsAppliedForFees": "false",
+    "reasonForDivorceClaiming5YearSeparation": "false",
+    "reasonForDivorceClaimingAdultery": "true",
+    "court": {
+      "eastMidlands": {
+        "divorceCentre": "East Midlands Regional Divorce Centre",
+        "courtCity": "Nottingham",
+        "poBox": "PO Box 10447",
+        "postCode": "NG2 9QN",
+        "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+        "email": "eastmidlandsdivorce@hmcts.gsi.gov.uk",
+        "phoneNumber": "0300 303 0642",
+        "siteId": "AA01"
+      },
+      "westMidlands": {
+        "divorceCentre": "West Midlands Regional Divorce Centre",
+        "courtCity": "Stoke-on-Trent",
+        "poBox": "PO Box 3650",
+        "postCode": "ST4 9NH",
+        "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+        "email": "westmidlandsdivorce@hmcts.gsi.gov.uk",
+        "phoneNumber": "0300 303 0642",
+        "siteId": "AA02"
+      },
+      "southWest": {
+        "divorceCentre": "South West Regional Divorce Centre",
+        "courtCity": "Southampton",
+        "poBox": "PO Box 1792",
+        "postCode": "SO15 9GG",
+        "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+        "email": "sw-region-divorce@hmcts.gsi.gov.uk",
+        "phoneNumber": "0300 303 0642",
+        "siteId": "AA03"
+      },
+      "northWest": {
+        "divorceCentre": "North West Regional Divorce Centre",
+        "divorceCentreAddressName": "Liverpool Civil & Family Court",
+        "courtCity": "Liverpool",
+        "street": "35 Vernon Street",
+        "postCode": "L2 2BX",
+        "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+        "email": "family@liverpool.countycourt.gsi.gov.uk",
+        "phoneNumber": "0300 303 0642",
+        "siteId": "AA04"
+      },
+      "serviceCentre": {
+        "serviceCentreName": "Courts and Tribunals Service Centre",
+        "divorceCentre": "East Midlands Regional Divorce Centre",
+        "courtCity": "Nottingham",
+        "poBox": "PO Box 10447",
+        "postCode": "NG2 9QN",
+        "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+        "email": "divorcecase@justice.gov.uk",
+        "phoneNumber": "0300 303 0642",
+        "siteId": "AA01"
+      }
+    },
+    "courts": "serviceCentre",
+    "confirmPrayer": "Yes",
+    "payment": {
+      "PaymentChannel": "online",
+      "PaymentTransactionId": "r3po2u2e4qf3ganoohb4051rb4",
+      "PaymentReference": "RC-1550-8482-8255-7754",
+      "PaymentDate": "22022019",
+      "PaymentAmount": "55000",
+      "PaymentStatus": "Success",
+      "PaymentFeeId": "FEE0002",
+      "PaymentSiteId": "AA04"
+    },
+    "marriageCertificateFiles": [
+      {
+        "createdBy": 0,
+        "createdOn": "2019-02-22T00:00:00.000+0000",
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "Screenshot 2019-02-22 at 13.09.15.png",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/c36adbbb-5fbb-4db2-baf5-e806540f5c93",
+        "mimeType": null,
+        "status": null
+      }
+    ],
+    "petitionerConsent": "Yes",
+    "createdDate": "2019-02-22T00:00:00.000+0000",
+    "issueDate": "2019-02-22T00:00:00.000+0000",
+    "dueDate": "2019-03-24T00:00:00.000+0000",
+    "respondentContactDetailsConfidential": "share",
+    "coRespondentAnswers": {
+      "contactInfo": {
+        "emailAddress": "user@email.com"
+      },
+      "aos": {
+        "received": "Yes",
+        "letterHolderId": "755791",
+        "dateReceived": "2019-02-22"
+      },
+      "defendsDivorce": "No"
+    },
+    "d8": [
+      {
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "d8petition1550848268807298.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/67c96669-07d5-4f06-a3a9-1bc2886ca4c7",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "aosinvitation1550848268807298.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/f8acddb7-b0b4-4857-8a08-3e93053e452d",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "co-respondentaosinvitation1550848268807298.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/88217833-f74f-4cc3-ae73-f66d61f7f4d4",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "id": "88217833-f74f-4cc3-ae73-882178332ccd",
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "certificateOfEntitlement1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/88217833-f74f-4cc3-ae73-asdasfasd21",
+        "mimeType": null,
+        "status": null
+      }
+    ]
+  }
+}

--- a/mocks/steps/idamLogin/IdamLogin.content.json
+++ b/mocks/steps/idamLogin/IdamLogin.content.json
@@ -28,6 +28,7 @@
         "coRespDefendingWaitingAnswer": "Co-respondent user responded - defending waiting answer (has docs)",
         "coRespDefendingSubmittedAnswer": "Co-respondent user responded - defending submitted answer",
         "coRespTooLateToRespond": "Co-respondent not responded - Divorce Granted",
+        "coRespAwaitingPronouncementHearingDataFuture": "Co-respondent - Awaiting Pronouncement and Hearing data in future",
         "throwError": "Simulate 500 server error"
       }
     }

--- a/mocks/steps/idamLogin/IdamLogin.step.js
+++ b/mocks/steps/idamLogin/IdamLogin.step.js
@@ -34,6 +34,7 @@ class IdamLogin extends Question {
       'coRespDefendingWaitingAnswer',
       'coRespDefendingSubmittedAnswer',
       'coRespTooLateToRespond',
+      'coRespAwaitingPronouncementHearingDataFuture',
       'throwError'
     ];
     const validAnswers = Joi.string()

--- a/mocks/steps/idamLogin/IdamLogin.template.html
+++ b/mocks/steps/idamLogin/IdamLogin.template.html
@@ -33,6 +33,7 @@
                 { label: content.fields.success.coRespDefendingWaitingAnswer, value: "coRespDefendingWaitingAnswer" },
                 { label: content.fields.success.coRespDefendingSubmittedAnswer, value: "coRespDefendingSubmittedAnswer" },
                 { label: content.fields.success.coRespTooLateToRespond, value: "coRespTooLateToRespond" },
+                { label: content.fields.success.coRespAwaitingPronouncementHearingDataFuture, value: "coRespAwaitingPronouncementHearingDataFuture" },
                 { label: content.fields.success.throwError, value: "throwError" }
             ]
         ) }}

--- a/steps/co-respondent/cr-progress-bar/CrProgressBar.content.json
+++ b/steps/co-respondent/cr-progress-bar/CrProgressBar.content.json
@@ -7,8 +7,7 @@
     },
     "downloadableFiles": "Download your documents",
     "files": {
-      "dpetition": "Divorce application",
-      "respondentAnswers": "Respondent's answers"
+      "dpetition": "Divorce application"
     },
     "tooLateToRespond": {
       "heading": "Contact the Courts and Tribunals Service Centre",
@@ -52,6 +51,16 @@
       "decreeNisiLink": "<a href=\"https://www.gov.uk/divorce/apply-for-decree-nisi\" target=\"_blank\" aria-label=\"This link will open in a new tab.\">Get a divorce</a>",
       "childrenAndDivorceLink": "<a href=\"https://www.gov.uk/looking-after-children-divorce/overview\" target=\"_blank\" aria-label=\"This link will open in a new tab.\">Children and divorce</a>",
       "moneyAndPropertyLink": "<a href=\"https://www.gov.uk/money-property-when-relationship-ends\" target=\"_blank\" aria-label=\"This link will open in a new tab.\">Money and property</a>"
+    },
+    "awaitingPronouncementHearingDataFuture": {
+      "title": "The application for a decree nisi has been accepted",
+      "districtJudge": "A district judge will formally announce the decree nisi at a court hearing. This is the first stage of the decree ending the marriage.",
+      "orderPayDivorceCosts": "The court has also decided to make an order that you pay towards the divorce costs.",
+      "divorceOnlyComplete": "The divorce is only complete when the decree absolute has been granted.",
+      "theHearing": "The hearing",
+      "findMoreDetails": "You can find more details about the date of the hearing and the orders that will be made (including costs orders) in the Entitlement to a decree (beta: document link not available yet).",
+      "wantToObject": "You don’t need to come to the hearing unless you want to object to the costs order.",
+      "attendTheHearing": "If you want to attend the hearing, you need to email the court before the hearing date. If you want to dispute a costs order, the court must receive a letter or email stating the reasons for doing so at least 14 days before the hearing date."
     }
   }
 }

--- a/steps/co-respondent/cr-progress-bar/CrProgressBar.html
+++ b/steps/co-respondent/cr-progress-bar/CrProgressBar.html
@@ -74,6 +74,30 @@
         <p>{{ content.tooLateToRespond.info }}</p>
     {% endif %}
 
+    {% if  progressBarContent === progressStates.awaitingPronouncementHearingDataFuture %}
+        <h2 class="heading-medium">{{ content.awaitingPronouncementHearingDataFuture.title }}</h2>
+        <p>{{ content.awaitingPronouncementHearingDataFuture.districtJudge }}</p>
+        {% if coRespondentPaysCosts %}
+            <p>{{ content.awaitingPronouncementHearingDataFuture.orderPayDivorceCosts }}</p>
+        {% endif %}
+        <div class="panel panel-border-wide">
+            <p>{{ content.awaitingPronouncementHearingDataFuture.divorceOnlyComplete }}</p>
+        </div>
+
+        <h2 class="heading-medium">{{ content.awaitingPronouncementHearingDataFuture.theHearing }}</h2>
+        <p>{{ content.awaitingPronouncementHearingDataFuture.findMoreDetails | safe }}</p>
+        {% if coRespondentPaysCosts %}
+            <div class="notice">
+                <em class="icon icon-important">
+                    <span class="visually-hidden">Warning</span>
+                </em>
+                <strong class="bold-xsmall">{{ content.awaitingPronouncementHearingDataFuture.wantToObject }}</strong>
+            </div>
+        {% endif %}
+        <br>
+        <p>{{ content.awaitingPronouncementHearingDataFuture.attendTheHearing }}</p>
+    {% endif %}
+
 {% endblock %}
 
 {% block one_third %}
@@ -93,6 +117,12 @@
             </li>
             {% include "includes/sideMenuCourtDetails.html" %}
         </ul>
+        {% if (downloadableFiles.length > 0) %}
+            <h3 class="heading-small" id="subsection-title">{{ content.downloadableFiles }}</h3>
+
+            {{ documentList(downloadableFiles, content.files) }}
+        {% endif %}
+
         {% if (downloadableFiles.length > 0) %}
             <h3 class="heading-small" id="subsection-title">{{ content.downloadableFiles }}</h3>
 

--- a/steps/co-respondent/cr-progress-bar/CrProgressBar.html
+++ b/steps/co-respondent/cr-progress-bar/CrProgressBar.html
@@ -117,11 +117,6 @@
             </li>
             {% include "includes/sideMenuCourtDetails.html" %}
         </ul>
-        {% if (downloadableFiles.length > 0) %}
-            <h3 class="heading-small" id="subsection-title">{{ content.downloadableFiles }}</h3>
-
-            {{ documentList(downloadableFiles, content.files) }}
-        {% endif %}
 
         {% if (downloadableFiles.length > 0) %}
             <h3 class="heading-small" id="subsection-title">{{ content.downloadableFiles }}</h3>

--- a/steps/co-respondent/cr-respond/CrRespond.content.json
+++ b/steps/co-respondent/cr-respond/CrRespond.content.json
@@ -25,8 +25,7 @@
     },
     "downloadableFiles": "Download your documents",
     "files": {
-      "dpetition": "Divorce application",
-      "respondentAnswers": "Respondent's answers"
+      "dpetition": "Divorce application"
     }
   }
 }

--- a/steps/respondent/progress-bar/ProgressBar.content.json
+++ b/steps/respondent/progress-bar/ProgressBar.content.json
@@ -8,7 +8,8 @@
     "downloadableFiles": "Download your documents",
     "files": {
       "dpetition": "Divorce application",
-      "respondentAnswers": "Your answers"
+      "respondentAnswers": "Your answers",
+      "aosinvitation": "Acknowledgement of Service"
     },
     "details": {
       "referenceNumber": "Reference number",

--- a/test/e2e/pages/co-respondent/crProgressBar.js
+++ b/test/e2e/pages/co-respondent/crProgressBar.js
@@ -43,9 +43,11 @@ function seePetitionToDownload() {
   I.see(content.en.files.dpetition);
 }
 
-function seeRespondentAnswersToDownload() {
+function seeCoRespAwaitingPronouncementHearingDataFuture() {
   const I = this;
-  I.see(content.en.files.respondentAnswers);
+
+  I.see(content.en.awaitingPronouncementHearingDataFuture.title);
+  I.see(content.en.awaitingPronouncementHearingDataFuture.districtJudge);
 }
 
 module.exports = {
@@ -55,5 +57,5 @@ module.exports = {
   seeContentForNotDefendingSubmittedAnswer,
   seeContentForTooLateToRespond,
   seePetitionToDownload,
-  seeRespondentAnswersToDownload
+  seeCoRespAwaitingPronouncementHearingDataFuture
 };

--- a/test/e2e/pages/co-respondent/crRespond.step.js
+++ b/test/e2e/pages/co-respondent/crRespond.step.js
@@ -11,7 +11,6 @@ function seeCrRespondPage() {
 function seeCrDocumentsForDownload() {
   const I = this;
   I.waitForText(content.en.files.dpetition);
-  I.waitForText(content.en.files.respondentAnswers);
 }
 
 module.exports = {

--- a/test/e2e/pages/common/idam.step.js
+++ b/test/e2e/pages/common/idam.step.js
@@ -138,6 +138,13 @@ function loginAsCoRespTooLateToRespond() {
   I.click(commonContent.en.continue);
 }
 
+function loginAsCoRespAwaitingPronouncementHearingDataFuture() {
+  const I = this;
+
+  I.click(content.en.fields.success.coRespAwaitingPronouncementHearingDataFuture);
+  I.click(commonContent.en.continue);
+}
+
 function loginAndThrowError() {
   const I = this;
 
@@ -165,5 +172,6 @@ module.exports = {
   loginAsCoRespDefendingWaitingAnswer,
   loginAsCoRespDefendingSubmittedAnswer,
   loginAsCoRespTooLateToRespond,
+  loginAsCoRespAwaitingPronouncementHearingDataFuture,
   loginAndThrowError
 };

--- a/test/e2e/paths/co-respondent/progressBar.js
+++ b/test/e2e/paths/co-respondent/progressBar.js
@@ -36,3 +36,11 @@ Scenario('Should display content for co-respondent - Too late to Respond', I => 
   I.seeContentForTooLateToRespond();
   I.seePetitionToDownload();
 }).retry(2);
+
+Scenario('Should display content for co-respondent - awaiting pronouncement and hearing date in the future', I => { // eslint-disable-line max-len
+  I.amOnPage('/');
+  I.seeIdamLoginPage();
+  I.loginAsCoRespAwaitingPronouncementHearingDataFuture();
+  I.seeCrProgressBarPage();
+  I.seeCoRespAwaitingPronouncementHearingDataFuture();
+}).retry(2);

--- a/test/unit/steps/corespondent/crProgressBar.test.js
+++ b/test/unit/steps/corespondent/crProgressBar.test.js
@@ -155,6 +155,116 @@ describe(modulePath, () => {
     });
   });
 
+  it('shows content for files if they exsist', () => {
+    const session = {
+      caseState: 'AwaitingPronouncement',
+      originalPetition: {
+        coRespondentAnswers: {
+          contactInfo: {
+            emailAddress: 'user@email.com'
+          },
+          aos: {
+            received: 'Yes',
+            letterHolderId: '755791',
+            dateReceived: '2019-02-22'
+          },
+          defendsDivorce: 'Yes',
+          answer: {
+            received: 'Yes'
+          }
+        },
+        hearingDate: ['3000-01-01T00:00:00.000+0000'],
+        d8: [
+          {
+            id: '88217833-f74f-4cc3-ae73-882178332ccd',
+            fileName: 'd8petition1539017559370699.pdf'
+          }
+        ]
+      }
+    };
+    return content(CrProgressBar, session, {
+      specificContent: [
+        'downloadableFiles',
+        'files.dpetition'
+      ]
+    });
+  });
+
+  describe('content for awaiting pronouncement and hearing date in the future', () => { // eslint-disable-line max-len
+    const session = {
+      caseState: 'AwaitingPronouncement',
+      originalPetition: {
+        coRespondentAnswers: {
+          contactInfo: {
+            emailAddress: 'user@email.com'
+          },
+          aos: {
+            received: 'Yes',
+            letterHolderId: '755791',
+            dateReceived: '2019-02-22'
+          },
+          defendsDivorce: 'Yes',
+          answer: {
+            received: 'Yes'
+          }
+        },
+        hearingDate: ['3000-01-01T00:00:00.000+0000'],
+        d8: [
+          {
+            id: '88217833-f74f-4cc3-ae73-882178332ccd',
+            fileName: 'd8petition1539017559370699.pdf'
+          }
+        ]
+      }
+    };
+
+    it('shows costs content', () => {
+      session.originalPetition.costsClaimGranted = 'Yes';
+      session.originalPetition.whoPaysCosts = 'respondent and correspondent';
+      return content(CrProgressBar, session, {
+        specificContent: [
+          'awaitingPronouncementHearingDataFuture.title',
+          'awaitingPronouncementHearingDataFuture.districtJudge',
+          'awaitingPronouncementHearingDataFuture.orderPayDivorceCosts',
+          'awaitingPronouncementHearingDataFuture.divorceOnlyComplete',
+          'awaitingPronouncementHearingDataFuture.theHearing',
+          'awaitingPronouncementHearingDataFuture.findMoreDetails',
+          'awaitingPronouncementHearingDataFuture.wantToObject',
+          'awaitingPronouncementHearingDataFuture.attendTheHearing'
+        ]
+      });
+    });
+
+    it('doesnt show costs content', () => {
+      session.originalPetition.costsClaimGranted = 'No';
+      return content(CrProgressBar, session, {
+        specificContentToNotExist: [
+          'awaitingPronouncementHearingDataFuture.orderPayDivorceCosts',
+          'awaitingPronouncementHearingDataFuture.wantToObject'
+        ]
+      });
+    });
+  });
+
+  it('renders the content for awaiting Pronouncement and Hearing Data in the Future - Too late to respond', () => { // eslint-disable-line max-len
+    const session = {
+      caseState: 'DivorceGranted',
+      originalPetition: {
+        coRespondentAnswers: {
+          contactInfo: {
+            emailAddress: 'user@email.com'
+          }
+        }
+      }
+    };
+    return content(CrProgressBar, session, {
+      specificValues: [
+        CrProgressBarContent.en.tooLateToRespond.heading,
+        CrProgressBarContent.en.tooLateToRespond.info
+      ]
+    });
+  });
+
 
   describe('court address details', () => {
     const basicSession = {
@@ -181,16 +291,6 @@ describe(modulePath, () => {
             lastModifiedBy: 0,
             modifiedOn: null,
             fileName: 'd8petition1539017559370699.pdf',
-            fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/',
-            mimeType: null,
-            status: null
-          },
-          {
-            createdBy: 0,
-            createdOn: null,
-            lastModifiedBy: 0,
-            modifiedOn: null,
-            fileName: 'respondentAnswers.pdf',
             fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/',
             mimeType: null,
             status: null
@@ -262,8 +362,7 @@ describe(modulePath, () => {
               .and.to.include('How to respond to a divorce application')
               .and.to.include('Get a divorce')
               .and.to.include('Download your documents')
-              .and.to.include('Divorce application (PDF)')
-              .and.to.include('Respondent\'s answers (PDF)')
+              .and.to.include('Divorce application')
               .and.to.include('Children and divorce')
               .and.to.include('Money and property');
           });

--- a/test/unit/steps/corespondent/crRespond.test.js
+++ b/test/unit/steps/corespondent/crRespond.test.js
@@ -71,9 +71,8 @@ describe(modulePath, () => {
     ];
 
     it('should render contents when previousCaseId is not specified', () => {
-      return content(CrRespond, {
-        originalPetition: { }
-      }, {
+      const session = { originalPetition: { d8: [] } };
+      return content(CrRespond, session, {
         ignoreContent,
         specificContent: ['readApp']
       });
@@ -82,6 +81,7 @@ describe(modulePath, () => {
     it('should render contents when previousCaseId is null', () => {
       return content(CrRespond, {
         originalPetition: {
+          d8: [],
           previousCaseId: null
         }
       }, {
@@ -93,6 +93,7 @@ describe(modulePath, () => {
     it('should render contents when previousCaseId is specified', () => {
       return content(CrRespond, {
         originalPetition: {
+          d8: [],
           previousCaseId: '12345'
         }
       }, {
@@ -105,6 +106,7 @@ describe(modulePath, () => {
   describe('court address details', () => {
     describe('when divorce unit handles case', () => {
       const session = buildSessionWithCourtsInfo('westMidlands');
+      session.originalPetition = { d8: [] };
 
       it('should render the divorce unit info', () => {
         return custom(CrRespond)
@@ -122,6 +124,7 @@ describe(modulePath, () => {
 
     describe('when service centre handles case', () => {
       const session = buildSessionWithCourtsInfo('serviceCentre');
+      session.originalPetition = { d8: [] };
 
       it('some contents should exist', () => {
         return custom(CrRespond)
@@ -138,6 +141,7 @@ describe(modulePath, () => {
 
     describe('when RDC handles case', () => {
       const session = buildSessionWithCourtsInfo('northWest');
+      session.originalPetition = { d8: [] };
 
       it('some contents should exist', () => {
         return custom(CrRespond)
@@ -190,12 +194,30 @@ describe(modulePath, () => {
               .and.to.include('How to respond to a divorce application')
               .and.to.include('Get a divorce')
               .and.to.include('Download your documents')
-              .and.to.include('Divorce application (PDF)')
-              .and.to.include('Respondent\'s answers (PDF)')
+              .and.to.include('Divorce application')
               .and.to.include('Children and divorce')
               .and.to.include('Money and property');
           });
       });
+    });
+  });
+
+  it('shows content for files if they exsist', () => {
+    const session = {
+      originalPetition: {
+        d8: [
+          {
+            id: '88217833-f74f-4cc3-ae73-882178332ccd',
+            fileName: 'd8petition1539017559370699.pdf'
+          }
+        ]
+      }
+    };
+    return content(CrRespond, session, {
+      specificContent: [
+        'downloadableFiles',
+        'files.dpetition'
+      ]
     });
   });
 });

--- a/test/unit/steps/respondent/progressBar.test.js
+++ b/test/unit/steps/respondent/progressBar.test.js
@@ -164,8 +164,14 @@ describe(modulePath, () => {
     const session = {
       caseState: 'AosSubmittedAwaitingAnswer',
       originalPetition: {
+        coRespondentAnswers: {
+          contactInfo: {
+            emailAddress: 'corespemail'
+          }
+        },
         d8: [
           {
+            id: 'test-01',
             createdBy: 0,
             createdOn: null,
             lastModifiedBy: 0,
@@ -176,12 +182,13 @@ describe(modulePath, () => {
             status: null
           },
           {
+            id: 'test-02',
             createdBy: 0,
             createdOn: null,
             lastModifiedBy: 0,
             modifiedOn: null,
-            fileName: 'respondentAnswers.pdf',
-            fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/',
+            fileName: 'respondentAnswers12312412.pdf',
+            fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/respondentAnswers',
             mimeType: null,
             status: null
           }


### PR DESCRIPTION
# Description

[DIV-4462 - Co-respondent can see the details of the DN approval in their account](https://tools.hmcts.net/jira/browse/DIV-4462)
 - Add new page for co-respondent for when case is in AwaitingPronouncement and DateOfHearing in the future
 - Add list of files to right hand side of the page of the progress bar page for co-respondent