### PR TITLE
DIV-4622 screen reader reads case reference ID as seperate characters

### DIFF
--- a/steps/co-respondent/cr-done/CrDone.html
+++ b/steps/co-respondent/cr-done/CrDone.html
@@ -22,7 +22,7 @@
     <h1 class="bold-large">{{ content.responseSent }}</h1>
     <p class="text-reference">
         {{ content.referenceNumber }}<br>
-        <strong class="text-reference-number">{{ session.originalPetition.caseReference | safe }}</strong>
+        <strong class="text-reference-number" aria-label="{{ session.originalPetition.caseReference | a11yCharSeparator | safe }}">{{ session.originalPetition.caseReference | safe }}</strong>
     </p>
 </div>
 

--- a/steps/respondent/done/Done.html
+++ b/steps/respondent/done/Done.html
@@ -22,7 +22,7 @@
     <h1 class="bold-large">{{ content.responseSent }}</h1>
     <p class="text-reference">
       {{ content.referenceNumber }}<br>
-      <strong class="text-reference-number">{{ session.originalPetition.caseReference | safe }}</strong>
+      <strong class="text-reference-number" aria-label="{{ session.originalPetition.caseReference | a11yCharSeparator | safe }}">{{ session.originalPetition.caseReference | safe }}</strong>
     </p>
   </div>
 
@@ -172,7 +172,7 @@
       </li>
       {% include "includes/sideMenuCourtDetails.html" %}
     </ul>
-    
+
     {% include "includes/sideMenuGuidanceLinks.html" %}
   </aside>
 {% endblock %}

--- a/views/filters/a11y.js
+++ b/views/filters/a11y.js
@@ -1,0 +1,8 @@
+const a11yCharSeparator = input => {
+  if (typeof input === 'string') {
+    return input.split('').join(' ');
+  }
+  return input;
+};
+
+module.exports = a11yCharSeparator;


### PR DESCRIPTION
# Description

Previously when a screen reader would read the case reference Id it would ready numeric characters as numbers, e.g. an Id of `TOM123` would be read as `TOM one hundred and twenty three`, instead of `T O M one two three`. This change adds a nunjucks filter which spaces out each of the characters which is applied to an ARIA label, so that when a screen reader tries to read it out, the version that the screen reader reads will have a whitespace inbetween each character, causing it to read out each character indevidualy.

Fixes # (issue)
[Accessibility [AA] - Case ID Number](https://tools.hmcts.net/jira/browse/DIV-4622)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Enable a screen reader and check output when on the case identification number.
Unit testing of new filter functionality (WIP).

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
