### PR TITLE
DIV-4892 - Co-Respondent landing page with Cost Order

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -176,6 +176,7 @@ document:
     - 'd8petition'
     - 'coRespondentAnswers'
     - 'certificateOfEntitlement'
+    - 'costsOrder'
     respondent:
     - 'd8petition'
     - 'respondentAnswers'

--- a/mocks/services/case-orchestration/retrieve-aos-case/GET_Authorization=Bearer coRespDNPronouncedWithCosts.mock
+++ b/mocks/services/case-orchestration/retrieve-aos-case/GET_Authorization=Bearer coRespDNPronouncedWithCosts.mock
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+
+#import './mock-co-respondent-dnPronouncedWithCosts.json';

--- a/mocks/services/case-orchestration/retrieve-aos-case/GET_Authorization=Bearer coRespDNPronouncedWithoutCosts.mock
+++ b/mocks/services/case-orchestration/retrieve-aos-case/GET_Authorization=Bearer coRespDNPronouncedWithoutCosts.mock
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+
+#import './mock-co-respondent-dnPronouncedWithoutCosts.json';

--- a/mocks/services/case-orchestration/retrieve-aos-case/mock-co-respondent-dnPronouncedWithCosts.json
+++ b/mocks/services/case-orchestration/retrieve-aos-case/mock-co-respondent-dnPronouncedWithCosts.json
@@ -1,0 +1,309 @@
+{
+  "caseId": "1539017559370699",
+  "courts": "northWest",
+  "state": "DNPronounced",
+  "data": {
+    "decreeNisiGrantedDate": "2019-06-19T00:00:00.000+0000",
+    "costsClaimGranted": "Yes",
+    "whoPaysCosts": "respondentAndCoRespondent",
+    "coRespondentAnswers": {
+      "contactInfo": {
+        "emailAddress": "user@email.com"
+      },
+      "aos": {
+        "received": "Yes",
+        "letterHolderId": "755791",
+        "dateReceived": "2019-02-22"
+      },
+      "defendsDivorce": "No"
+    },
+    "hearingDate": ["2222-01-01T00:00:00.000+0000"],
+    "expires": 0,
+    "caseReference": "LV17D80999",
+    "screenHasMarriageBroken": "Yes",
+    "screenHasRespondentAddress": "Yes",
+    "screenHasMarriageCert": "Yes",
+    "helpWithFeesNeedHelp": "Yes",
+    "helpWithFeesAppliedForFees": "Yes",
+    "helpWithFeesReferenceNumber": "HWF-123-456",
+    "divorceWho": "wife",
+    "marriageIsSameSexCouple": "No",
+    "marriageDateDay": 1,
+    "marriageDateMonth": 1,
+    "marriageDateYear": 2000,
+    "marriageDate": "2000-01-01T00:00:00.000+0000",
+    "marriageCanDivorce": "true",
+    "marriedInUk": "Yes",
+    "jurisdictionConnection": [
+      "A",
+      "C"
+    ],
+    "connections": {
+      "A": "The Petitioner and the Respondent are habitually resident in England and Wales",
+      "B": null,
+      "C": "The Respondent is habitually resident in England and Wales",
+      "D": null,
+      "E": null,
+      "F": null,
+      "G": null
+    },
+    "jurisdictionPetitionerResidence": "Yes",
+    "jurisdictionRespondentResidence": "Yes",
+    "jurisdictionConfidentLegal": "Yes",
+    "petitionerContactDetailsConfidential": "share",
+    "petitionerFirstName": "BANANA",
+    "petitionerLastName": "ban",
+    "respondentFirstName": "Apple",
+    "respondentLastName": "App",
+    "marriagePetitionerName": "Ban",
+    "marriageRespondentName": "App",
+    "petitionerNameDifferentToMarriageCertificate": "No",
+    "petitionerEmail": "vivdivred@mailinator.com",
+    "petitionerHomeAddress": {
+      "addressType": "postcode",
+      "postcode": "SW10 0AB",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": true,
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": false,
+      "url": null,
+      "address": [
+        "Chelsea Academy",
+        "Lots Road",
+        "London",
+        "SW10 0AB"
+      ]
+    },
+    "petitionerCorrespondenceUseHomeAddress": "Yes",
+    "petitionerCorrespondenceAddress": {
+      "addressType": "postcode",
+      "postcode": "SW10 0AB",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": true,
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": false,
+      "url": null,
+      "address": [
+        "Chelsea Academy",
+        "Lots Road",
+        "London",
+        "SW10 0AB"
+      ]
+    },
+    "livingArrangementsLiveTogether": "Yes",
+    "respondentHomeAddress": {
+      "addressType": "postcode",
+      "postcode": "SW10 0AB",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": true,
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": false,
+      "url": null,
+      "address": [
+        "Chelsea Academy",
+        "Lots Road",
+        "London",
+        "SW10 0AB"
+      ]
+    },
+    "respondentCorrespondenceUseHomeAddress": "Yes",
+    "respondentCorrespondenceAddress": {
+      "addressType": "postcode",
+      "postcode": "SW10 0AB",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": true,
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": false,
+      "url": null,
+      "address": [
+        "Chelsea Academy",
+        "Lots Road",
+        "London",
+        "SW10 0AB"
+      ]
+    },
+    "reasonForDivorce": "separation-2-years",
+    "reasonForDivorceHasMarriageDate": "true",
+    "reasonForDivorceShowAdultery": "true",
+    "reasonForDivorceShowUnreasonableBehaviour": "true",
+    "reasonForDivorceShowTwoYearsSeparation": "true",
+    "reasonForDivorceShowFiveYearsSeparation": "true",
+    "reasonForDivorceShowDesertion": "true",
+    "reasonForDivorceLimitReasons": "false",
+    "reasonForDivorceEnableAdultery": "true",
+    "reasonForDivorceAdulteryWishToName": "Yes",
+    "reasonForDivorceAdultery3rdPartyFirstName": "Orange",
+    "reasonForDivorceAdultery3rdPartyLastName": "Orange",
+    "reasonForDivorceAdultery3rdAddress": {
+      "addressType": "postcode",
+      "postcode": "SW10 0AA",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": true,
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": false,
+      "url": null,
+      "address": [
+        "Apartment 2.1",
+        "1 Waterfront Drive",
+        "London",
+        "SW10 0AA"
+      ]
+    },
+    "reasonForDivorceAdulteryKnowWhere": "Yes",
+    "reasonForDivorceAdulteryKnowWhen": "Yes",
+    "reasonForDivorceAdulteryDetails": "I received several messages that night from Orange  boasting that she was with my husband and that they were having an affair. I confronted him about it the next day and he confessed and moved out of the house. We haven’t spoken since that day. I can provide text messages from both my Husband and Orange confessing to the adultery.",
+    "reasonForDivorceAdulteryWhenDetails": "New years eve 2018, At midnight.",
+    "reasonForDivorceAdulteryWhereDetails": "At a travelodge in Westminster  street, near central London.",
+    "legalProceedings": "Yes",
+    "legalProceedingsRelated": [
+      "marriage",
+      "property"
+    ],
+    "legalProceedingsDetails": "Mr text change\r\nmobile\r\n099889900990m is the mobile from where the messages sent .",
+    "financialOrder": "No",
+    "claimsCosts": "No",
+    "court": {
+      "eastMidlands": {
+        "divorceCentre": "East Midlands Regional Divorce Centre",
+        "courtCity": "Nottingham",
+        "poBox": "PO Box 10447",
+        "postCode": "NG2 9QN",
+        "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+        "email": "eastmidlandsdivorce@hmcts.gsi.gov.uk",
+        "phoneNumber": "0300 303 0642",
+        "siteId": "AA01"
+      },
+      "westMidlands": {
+        "divorceCentre": "West Midlands Regional Divorce Centre",
+        "courtCity": "Stoke-on-Trent",
+        "poBox": "PO Box 3650",
+        "postCode": "ST4 9NH",
+        "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+        "email": "westmidlandsdivorce@hmcts.gsi.gov.uk",
+        "phoneNumber": "0300 303 0642",
+        "siteId": "AA02"
+      },
+      "southWest": {
+        "divorceCentre": "South West Regional Divorce Centre",
+        "courtCity": "Southampton",
+        "poBox": "PO Box 1792",
+        "postCode": "SO15 9GG",
+        "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+        "email": "sw-region-divorce@hmcts.gsi.gov.uk",
+        "phoneNumber": "0300 303 0642",
+        "siteId": "AA03"
+      },
+      "northWest": {
+        "divorceCentre": "North West Regional Divorce Centre",
+        "divorceCentreAddressName": "Liverpool Civil & Family Court",
+        "courtCity": "Liverpool",
+        "street": "35 Vernon Street",
+        "postCode": "L2 2BX",
+        "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+        "email": "family@liverpool.countycourt.gsi.gov.uk",
+        "phoneNumber": "0300 303 0642",
+        "siteId": "AA04"
+      }
+    },
+    "courts": "northWest",
+    "confirmPrayer": "Yes",
+    "marriageCertificateFiles": [],
+    "d8": [
+      {
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "d8petition1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/430b333a-de02-4b16-8868-e6b1130aab2b",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "aosinvitation1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/a060ba13-d5da-45b0-a181-1c2ace891904",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "id": "1230fjasdhascertificateOfEntitlement10231283123",
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "certificateOfEntitlement1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/certificateOfEntitlement",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "id": "1230fjasdcoRespondentAnswers10231283123",
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "coRespondentAnswers1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/coRespondentAnswers",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "id": "1230fjasdhasrespondentAnswers10231283123",
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "respondentAnswers1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/respondentAnswers",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "id": "1230fjasddecreeNisi10231283123",
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "decreeNisi1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/decreeNisi",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "id": "costsOrder10231283123",
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "costsOrder1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/costsOrder",
+        "mimeType": null,
+        "status": null
+      }
+    ]
+  }
+}

--- a/mocks/services/case-orchestration/retrieve-aos-case/mock-co-respondent-dnPronouncedWithoutCosts.json
+++ b/mocks/services/case-orchestration/retrieve-aos-case/mock-co-respondent-dnPronouncedWithoutCosts.json
@@ -1,0 +1,309 @@
+{
+  "caseId": "1539017559370699",
+  "courts": "northWest",
+  "state": "DNPronounced",
+  "data": {
+    "decreeNisiGrantedDate": "2019-06-19T00:00:00.000+0000",
+    "costsClaimGranted": "Yes",
+    "whoPaysCosts": "respondent",
+    "coRespondentAnswers": {
+      "contactInfo": {
+        "emailAddress": "user@email.com"
+      },
+      "aos": {
+        "received": "Yes",
+        "letterHolderId": "755791",
+        "dateReceived": "2019-02-22"
+      },
+      "defendsDivorce": "No"
+    },
+    "hearingDate": ["2222-01-01T00:00:00.000+0000"],
+    "expires": 0,
+    "caseReference": "LV17D80999",
+    "screenHasMarriageBroken": "Yes",
+    "screenHasRespondentAddress": "Yes",
+    "screenHasMarriageCert": "Yes",
+    "helpWithFeesNeedHelp": "Yes",
+    "helpWithFeesAppliedForFees": "Yes",
+    "helpWithFeesReferenceNumber": "HWF-123-456",
+    "divorceWho": "wife",
+    "marriageIsSameSexCouple": "No",
+    "marriageDateDay": 1,
+    "marriageDateMonth": 1,
+    "marriageDateYear": 2000,
+    "marriageDate": "2000-01-01T00:00:00.000+0000",
+    "marriageCanDivorce": "true",
+    "marriedInUk": "Yes",
+    "jurisdictionConnection": [
+      "A",
+      "C"
+    ],
+    "connections": {
+      "A": "The Petitioner and the Respondent are habitually resident in England and Wales",
+      "B": null,
+      "C": "The Respondent is habitually resident in England and Wales",
+      "D": null,
+      "E": null,
+      "F": null,
+      "G": null
+    },
+    "jurisdictionPetitionerResidence": "Yes",
+    "jurisdictionRespondentResidence": "Yes",
+    "jurisdictionConfidentLegal": "Yes",
+    "petitionerContactDetailsConfidential": "share",
+    "petitionerFirstName": "BANANA",
+    "petitionerLastName": "ban",
+    "respondentFirstName": "Apple",
+    "respondentLastName": "App",
+    "marriagePetitionerName": "Ban",
+    "marriageRespondentName": "App",
+    "petitionerNameDifferentToMarriageCertificate": "No",
+    "petitionerEmail": "vivdivred@mailinator.com",
+    "petitionerHomeAddress": {
+      "addressType": "postcode",
+      "postcode": "SW10 0AB",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": true,
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": false,
+      "url": null,
+      "address": [
+        "Chelsea Academy",
+        "Lots Road",
+        "London",
+        "SW10 0AB"
+      ]
+    },
+    "petitionerCorrespondenceUseHomeAddress": "Yes",
+    "petitionerCorrespondenceAddress": {
+      "addressType": "postcode",
+      "postcode": "SW10 0AB",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": true,
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": false,
+      "url": null,
+      "address": [
+        "Chelsea Academy",
+        "Lots Road",
+        "London",
+        "SW10 0AB"
+      ]
+    },
+    "livingArrangementsLiveTogether": "Yes",
+    "respondentHomeAddress": {
+      "addressType": "postcode",
+      "postcode": "SW10 0AB",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": true,
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": false,
+      "url": null,
+      "address": [
+        "Chelsea Academy",
+        "Lots Road",
+        "London",
+        "SW10 0AB"
+      ]
+    },
+    "respondentCorrespondenceUseHomeAddress": "Yes",
+    "respondentCorrespondenceAddress": {
+      "addressType": "postcode",
+      "postcode": "SW10 0AB",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": true,
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": false,
+      "url": null,
+      "address": [
+        "Chelsea Academy",
+        "Lots Road",
+        "London",
+        "SW10 0AB"
+      ]
+    },
+    "reasonForDivorce": "separation-2-years",
+    "reasonForDivorceHasMarriageDate": "true",
+    "reasonForDivorceShowAdultery": "true",
+    "reasonForDivorceShowUnreasonableBehaviour": "true",
+    "reasonForDivorceShowTwoYearsSeparation": "true",
+    "reasonForDivorceShowFiveYearsSeparation": "true",
+    "reasonForDivorceShowDesertion": "true",
+    "reasonForDivorceLimitReasons": "false",
+    "reasonForDivorceEnableAdultery": "true",
+    "reasonForDivorceAdulteryWishToName": "Yes",
+    "reasonForDivorceAdultery3rdPartyFirstName": "Orange",
+    "reasonForDivorceAdultery3rdPartyLastName": "Orange",
+    "reasonForDivorceAdultery3rdAddress": {
+      "addressType": "postcode",
+      "postcode": "SW10 0AA",
+      "street1": null,
+      "street2": null,
+      "town": null,
+      "postcodeManual": null,
+      "addressConfirmed": true,
+      "addressAbroad": null,
+      "validPostcode": true,
+      "postcodeError": false,
+      "url": null,
+      "address": [
+        "Apartment 2.1",
+        "1 Waterfront Drive",
+        "London",
+        "SW10 0AA"
+      ]
+    },
+    "reasonForDivorceAdulteryKnowWhere": "Yes",
+    "reasonForDivorceAdulteryKnowWhen": "Yes",
+    "reasonForDivorceAdulteryDetails": "I received several messages that night from Orange  boasting that she was with my husband and that they were having an affair. I confronted him about it the next day and he confessed and moved out of the house. We haven’t spoken since that day. I can provide text messages from both my Husband and Orange confessing to the adultery.",
+    "reasonForDivorceAdulteryWhenDetails": "New years eve 2018, At midnight.",
+    "reasonForDivorceAdulteryWhereDetails": "At a travelodge in Westminster  street, near central London.",
+    "legalProceedings": "Yes",
+    "legalProceedingsRelated": [
+      "marriage",
+      "property"
+    ],
+    "legalProceedingsDetails": "Mr text change\r\nmobile\r\n099889900990m is the mobile from where the messages sent .",
+    "financialOrder": "No",
+    "claimsCosts": "No",
+    "court": {
+      "eastMidlands": {
+        "divorceCentre": "East Midlands Regional Divorce Centre",
+        "courtCity": "Nottingham",
+        "poBox": "PO Box 10447",
+        "postCode": "NG2 9QN",
+        "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+        "email": "eastmidlandsdivorce@hmcts.gsi.gov.uk",
+        "phoneNumber": "0300 303 0642",
+        "siteId": "AA01"
+      },
+      "westMidlands": {
+        "divorceCentre": "West Midlands Regional Divorce Centre",
+        "courtCity": "Stoke-on-Trent",
+        "poBox": "PO Box 3650",
+        "postCode": "ST4 9NH",
+        "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+        "email": "westmidlandsdivorce@hmcts.gsi.gov.uk",
+        "phoneNumber": "0300 303 0642",
+        "siteId": "AA02"
+      },
+      "southWest": {
+        "divorceCentre": "South West Regional Divorce Centre",
+        "courtCity": "Southampton",
+        "poBox": "PO Box 1792",
+        "postCode": "SO15 9GG",
+        "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+        "email": "sw-region-divorce@hmcts.gsi.gov.uk",
+        "phoneNumber": "0300 303 0642",
+        "siteId": "AA03"
+      },
+      "northWest": {
+        "divorceCentre": "North West Regional Divorce Centre",
+        "divorceCentreAddressName": "Liverpool Civil & Family Court",
+        "courtCity": "Liverpool",
+        "street": "35 Vernon Street",
+        "postCode": "L2 2BX",
+        "openingHours": "Telephone Enquiries from: 8.30am to 5pm",
+        "email": "family@liverpool.countycourt.gsi.gov.uk",
+        "phoneNumber": "0300 303 0642",
+        "siteId": "AA04"
+      }
+    },
+    "courts": "northWest",
+    "confirmPrayer": "Yes",
+    "marriageCertificateFiles": [],
+    "d8": [
+      {
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "d8petition1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/430b333a-de02-4b16-8868-e6b1130aab2b",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "aosinvitation1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/a060ba13-d5da-45b0-a181-1c2ace891904",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "id": "1230fjasdhascertificateOfEntitlement10231283123",
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "certificateOfEntitlement1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/certificateOfEntitlement",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "id": "1230fjasdcoRespondentAnswers10231283123",
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "coRespondentAnswers1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/coRespondentAnswers",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "id": "1230fjasdhasrespondentAnswers10231283123",
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "respondentAnswers1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/respondentAnswers",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "id": "1230fjasddecreeNisi10231283123",
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "decreeNisi1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/decreeNisi",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "id": "costsOrder10231283123",
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "costsOrder1539017559370699.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/costsOrder",
+        "mimeType": null,
+        "status": null
+      }
+    ]
+  }
+}

--- a/mocks/steps/idamLogin/IdamLogin.content.json
+++ b/mocks/steps/idamLogin/IdamLogin.content.json
@@ -32,6 +32,8 @@
         "coRespDefendingSubmittedAnswer": "Co-respondent user responded - defending submitted answer(   (+ co-resp answers doc)",
         "coRespTooLateToRespond": "Co-respondent not responded - Divorce Granted",
         "coRespAwaitingPronouncementHearingDataFuture": "Co-respondent - Awaiting Pronouncement and Hearing data in future",
+        "coRespDNPronouncedWithCosts": "Co-respondent - DNPronounced with costs",
+        "coRespDNPronouncedWithoutCosts": "Co-respondent - DNPronounced without costs",
         "throwError": "Simulate 500 server error"
       }
     }

--- a/mocks/steps/idamLogin/IdamLogin.step.js
+++ b/mocks/steps/idamLogin/IdamLogin.step.js
@@ -37,6 +37,8 @@ class IdamLogin extends Question {
       'coRespDefendingSubmittedAnswer',
       'coRespTooLateToRespond',
       'coRespAwaitingPronouncementHearingDataFuture',
+      'coRespDNPronouncedWithCosts',
+      'coRespDNPronouncedWithoutCosts',
       'throwError',
       'yesDecreeNisiPronouncement'
     ];

--- a/mocks/steps/idamLogin/IdamLogin.template.html
+++ b/mocks/steps/idamLogin/IdamLogin.template.html
@@ -37,6 +37,8 @@
                 { label: content.fields.success.coRespDefendingSubmittedAnswer, value: "coRespDefendingSubmittedAnswer" },
                 { label: content.fields.success.coRespTooLateToRespond, value: "coRespTooLateToRespond" },
                 { label: content.fields.success.coRespAwaitingPronouncementHearingDataFuture, value: "coRespAwaitingPronouncementHearingDataFuture" },
+                { label: content.fields.success.coRespDNPronouncedWithCosts, value: "coRespDNPronouncedWithCosts" },
+                { label: content.fields.success.coRespDNPronouncedWithoutCosts, value: "coRespDNPronouncedWithoutCosts" },
                 { label: content.fields.success.throwError, value: "throwError" }
             ]
         ) }}

--- a/steps/co-respondent/cr-progress-bar/CrProgressBar.content.json
+++ b/steps/co-respondent/cr-progress-bar/CrProgressBar.content.json
@@ -53,7 +53,7 @@
       "decreeNisi": "decree nisi - the first stage of the decree ending the marriage",
       "costsOrder": "costs order - giving your applicant the right to claim their divorce costs from you",
       "whatCostsOrder": "What to do with the costs order",
-      "costOrderDetails": "The order will state what the court has decided you must pay the applicant. You are required to pay them within 14 days of the order being made. If you don't pay within that time, your {{ session.divorceWho }} can use the order to make a civil money claim against you.",
+      "costOrderDetails": "The order will state what the court has decided you must pay the applicant. You are required to pay them within 14 days of the order being made. If you don't pay within that time, the applicant can use the order to make a civil money claim against you.",
       "downloadCostsOrder": "<a class=\"govuk-link\" href=\"{{ costsOrderFile.uri | safe }}\" target=\"_blank\" aria-label=\"This link will download the Costs Order PDF.\">Download your costs order</a> ({{ costsOrderFile.fileType | upper }})."
     },
     "yourCourt": "Your divorce centre",

--- a/steps/co-respondent/cr-progress-bar/CrProgressBar.content.json
+++ b/steps/co-respondent/cr-progress-bar/CrProgressBar.content.json
@@ -9,7 +9,8 @@
     "files": {
       "dpetition": "Divorce application",
       "coRespondentAnswers": "Your answers",
-      "certificateOfEntitlement": "Certificate Of Entitlement"
+      "certificateOfEntitlement": "Certificate Of Entitlement",
+      "costsOrder": "Cost order"
     },
     "tooLateToRespond": {
       "heading": "Contact the Courts and Tribunals Service Centre",
@@ -45,6 +46,15 @@
       "wantToObject": "You don’t need to come to the hearing unless you want to object to the costs order.",
       "attendTheHearing": "If you want to attend the hearing, you need to email the court before the hearing date.",
       "attendTheHearingCosts": " If you want to dispute a costs order, the court must receive a letter or email stating the reasons for doing so at least 14 days before the hearing date."
+    },
+    "decreeNisiGranted": {
+      "heading": "The decree nisi has been granted",
+      "dateGranted": "On {{ session.originalPetition.decreeNisiGrantedDate | date }} the court granted a:",
+      "decreeNisi": "decree nisi - the first stage of the decree ending the marriage",
+      "costsOrder": "costs order - giving your applicant the right to claim their divorce costs from you",
+      "whatCostsOrder": "What to do with the costs order",
+      "costOrderDetails": "The order will state what the court has decided you must pay the applicant. You are required to pay them within 14 days of the order being made. If you don't pay within that time, your {{ session.divorceWho }} can use the order to make a civil money claim against you.",
+      "downloadCostsOrder": "<a class=\"govuk-link\" href=\"{{ costsOrderFile.uri | safe }}\" target=\"_blank\" aria-label=\"This link will download the Costs Order PDF.\">Download your costs order</a> ({{ costsOrderFile.fileType | upper }})."
     },
     "yourCourt": "Your divorce centre",
     "careOfAbbreviation": "c/o",

--- a/steps/co-respondent/cr-progress-bar/CrProgressBar.html
+++ b/steps/co-respondent/cr-progress-bar/CrProgressBar.html
@@ -105,6 +105,25 @@
         }) }}
     {% endif %}
 
+    {% if progressBarContent === progressStates.dnPronounced %}
+        <h2 class="govuk-heading-m">{{ content.decreeNisiGranted.heading }}</h2>
+
+        <p class="govuk-body">{{ content.decreeNisiGranted.dateGranted }}</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>{{ content.decreeNisiGranted.decreeNisi }}</li>
+            {% if (coRespondentPaysCosts) %}
+                <li>{{ content.decreeNisiGranted.costsOrder }}</li>
+            {% endif %}
+        </ul>
+
+        {% if (coRespondentPaysCosts) %}
+            <h2 class="govuk-heading-m">{{ content.decreeNisiGranted.whatCostsOrder }}</h2>
+            <p class="govuk-body">{{ content.decreeNisiGranted.costOrderDetails }}</p>
+            <p class="govuk-body">{{ content.decreeNisiGranted.downloadCostsOrder | safe }}</p>
+        {% endif %}
+
+    {% endif %}
+
 {% endblock %}
 
 {% block one_third %}

--- a/steps/respondent/progress-bar/ProgressBar.html
+++ b/steps/respondent/progress-bar/ProgressBar.html
@@ -154,52 +154,44 @@
     {% endif %}
 
     {% if progressBarContent === progressStates.dnPronounced %}
-        <h2 class="heading-medium">{{ content.decreeNisiGranted.heading }}</h2>
+        <h2 class="govuk-heading-m">{{ content.decreeNisiGranted.heading }}</h2>
 
-        <p class="test">{{ content.decreeNisiGranted.dateGranted }}</p>
-        <ul class="list-bullet">
+        <p class="govuk-body">{{ content.decreeNisiGranted.dateGranted }}</p>
+        <ul class="govuk-list govuk-list--bullet">
             <li>{{ content.decreeNisiGranted.decreeNisi }}</li>
             {% if (costsOrderFile) %}
                 <li>{{ content.decreeNisiGranted.costsOrder }}</li>
             {% endif %}
         </ul>
 
-        <br>
+        {{ warningText({
+          text: content.decreeNisiGranted.notDivorcedYet,
+          iconFallbackText: content.warning
+        }) }}
 
-        <div class="notice-padding">
-            <div class="notice">
-                <em class="icon icon-important">
-                    <span class="visually-hidden">{{ content.warning }}</span>
-                </em>
-                <strong class="bold-small">
-                    {{ content.decreeNisiGranted.notDivorcedYet | safe }}
-                </strong>
-            </div>
-        </div>
+        <h2 class="govuk-heading-m">{{ content.decreeNisiGranted.divorceComplete }}</h2>
 
-        <h2 class="heading-medium">{{ content.decreeNisiGranted.divorceComplete }}</h2>
-
-        <p class="text">{{ content.decreeNisiGranted.sixWeeks }}</p>
-        <p class="text">{{ content.decreeNisiGranted.courtCancel }}</p>
-        <p class="text">{{ content.decreeNisiGranted.applyForDecreeAbsolute }}</p>
-        <p class="text">{{ content.decreeNisiGranted.downloadDecreeNisi | safe }}</p>
+        <p class="govuk-body">{{ content.decreeNisiGranted.sixWeeks }}</p>
+        <p class="govuk-body">{{ content.decreeNisiGranted.courtCancel }}</p>
+        <p class="govuk-body">{{ content.decreeNisiGranted.applyForDecreeAbsolute }}</p>
+        <p class="govuk-body">{{ content.decreeNisiGranted.downloadDecreeNisi | safe }}</p>
 
         {% if (costsOrderFile) %}
-            <h2 class="heading-medium">{{ content.decreeNisiGranted.whatCostsOrder }}</h2>
+            <h2 class="govuk-heading-m">{{ content.decreeNisiGranted.whatCostsOrder }}</h2>
 
             {% if (session.originalPetition.whoPaysCosts === 'respondent') %}
-                <p class="text">{{ content.decreeNisiGranted.orderWillStateRespondent }}</p>
+                <p class="govuk-body">{{ content.decreeNisiGranted.orderWillStateRespondent }}</p>
             {% endif %}
 
             {% if (session.originalPetition.whoPaysCosts === 'coRespondent') %}
-                <p class="text">{{ content.decreeNisiGranted.orderWillStateCoRespondent }}</p>
+                <p class="govuk-body">{{ content.decreeNisiGranted.orderWillStateCoRespondent }}</p>
             {% endif %}
 
             {% if (session.originalPetition.whoPaysCosts === 'respondentAndCoRespondent') %}
-                <p class="text">{{ content.decreeNisiGranted.orderWillStateRespondentAndCoRespondent }}</p>
+                <p class="govuk-body">{{ content.decreeNisiGranted.orderWillStateRespondentAndCoRespondent }}</p>
             {% endif %}
 
-            <p class="text">{{ content.decreeNisiGranted.downloadCostsOrder | safe }}</p>
+            <p class="govuk-body">{{ content.decreeNisiGranted.downloadCostsOrder | safe }}</p>
         {% endif %}
     {% endif %}
 

--- a/test/e2e/pages/co-respondent/crProgressBar.js
+++ b/test/e2e/pages/co-respondent/crProgressBar.js
@@ -53,11 +53,30 @@ function seeCoRespAnswersToDownload() {
   I.see(content.en.files.coRespondentAnswers);
 }
 
+function seeCoRespCostsOrderToDownload() {
+  const I = this;
+  I.see(content.en.files.costsOrder);
+}
+
 function seeCoRespAwaitingPronouncementHearingDataFuture() {
   const I = this;
 
   I.see(content.en.awaitingPronouncementHearingDataFuture.title);
   I.see(content.en.awaitingPronouncementHearingDataFuture.districtJudge);
+}
+
+function seeCoRespDNPronouncedAndCosts() {
+  const I = this;
+
+  I.see(content.en.decreeNisiGranted.heading);
+  I.see(content.en.decreeNisiGranted.decreeNisi);
+}
+
+function seeCoRespDNPronouncedWithoutCosts() {
+  const I = this;
+
+  I.see(content.en.notDefending.heading);
+  I.see(content.en.notDefending.info);
 }
 
 module.exports = {
@@ -69,5 +88,8 @@ module.exports = {
   seePetitionToDownload,
   seeRespAnswersToDownload,
   seeCoRespAnswersToDownload,
-  seeCoRespAwaitingPronouncementHearingDataFuture
+  seeCoRespCostsOrderToDownload,
+  seeCoRespAwaitingPronouncementHearingDataFuture,
+  seeCoRespDNPronouncedAndCosts,
+  seeCoRespDNPronouncedWithoutCosts
 };

--- a/test/e2e/pages/common/idam.step.js
+++ b/test/e2e/pages/common/idam.step.js
@@ -159,6 +159,20 @@ function loginAsCoRespAwaitingPronouncementHearingDataFuture() {
   I.click(commonContent.en.continue);
 }
 
+function loginAsCoRespDNPronouncedAndCostsOrder() {
+  const I = this;
+
+  I.click(content.en.fields.success.coRespDNPronouncedWithCosts);
+  I.click(commonContent.en.continue);
+}
+
+function loginAsCoRespDNPronouncedWithoutCostsOrder() {
+  const I = this;
+
+  I.click(content.en.fields.success.coRespDNPronouncedWithoutCosts);
+  I.click(commonContent.en.continue);
+}
+
 function loginAndThrowError() {
   const I = this;
 
@@ -187,6 +201,8 @@ module.exports = {
   loginAsCoRespDefendingSubmittedAnswer,
   loginAsCoRespTooLateToRespond,
   loginAsCoRespAwaitingPronouncementHearingDataFuture,
+  loginAsCoRespDNPronouncedAndCostsOrder,
+  loginAsCoRespDNPronouncedWithoutCostsOrder,
   loginAndThrowError,
   loginAsCaseAwaitingDecreeAbsolute,
   loginAsCaseDNPronounced

--- a/test/e2e/paths/co-respondent/progressBar.js
+++ b/test/e2e/paths/co-respondent/progressBar.js
@@ -46,3 +46,20 @@ Scenario('Should display content for co-respondent - awaiting pronouncement and 
   I.seeCrProgressBarPage();
   I.seeCoRespAwaitingPronouncementHearingDataFuture();
 }).retry(2);
+
+Scenario('Should display content for co-respondent - DNPronounced with costs orde', I => { // eslint-disable-line max-len
+  I.amOnPage('/');
+  I.seeIdamLoginPage();
+  I.loginAsCoRespDNPronouncedAndCostsOrder();
+  I.seeCrProgressBarPage();
+  I.seeCoRespDNPronouncedAndCosts();
+  I.seeCoRespCostsOrderToDownload();
+}).retry(2);
+
+Scenario('Should display content for co-respondent - DNPronounced without costs order', I => { // eslint-disable-line max-len
+  I.amOnPage('/');
+  I.seeIdamLoginPage();
+  I.loginAsCoRespDNPronouncedWithoutCostsOrder();
+  I.seeCrProgressBarPage();
+  I.seeCoRespDNPronouncedWithoutCosts();
+}).retry(2);

--- a/test/unit/steps/corespondent/crProgressBar.test.js
+++ b/test/unit/steps/corespondent/crProgressBar.test.js
@@ -231,6 +231,122 @@ describe(modulePath, () => {
     });
   });
 
+  describe('handle state DNPronounced and co respondent pays costs', () => {
+    const basicSession = {
+      caseState: 'DNPronounced',
+      originalPetition: {
+        costsClaimGranted: 'Yes',
+        whoPaysCosts: 'respondentAndCoRespondent',
+        decreeNisiGrantedDate: '2019-07-01T00:00:00.000+0000',
+        coRespondentAnswers: {
+          contactInfo: {
+            emailAddress: 'user@email.com'
+          },
+          aos: {
+            received: 'Yes',
+            letterHolderId: '755791',
+            dateReceived: '2019-02-22'
+          },
+          defendsDivorce: 'Yes',
+          answer: {
+            received: 'Yes'
+          }
+        },
+        d8: [
+          {
+            id: '401ab79e-34cb-4570-9f2f-4cf9357m4st3r',
+            fileName: 'costsOrder1554740111371638.pdf',
+            // eslint-disable-next-line max-len
+            fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560113f'
+          }
+        ]
+      }
+    };
+
+    it('shows correct content', () => {
+      content(CrProgressBar, basicSession, {
+        specificContent: [
+          'decreeNisiGranted.heading',
+          'decreeNisiGranted.dateGranted',
+          'decreeNisiGranted.decreeNisi',
+          'decreeNisiGranted.costsOrder',
+          'decreeNisiGranted.whatCostsOrder',
+          'decreeNisiGranted.costOrderDetails',
+          'decreeNisiGranted.downloadCostsOrder'
+        ]
+      });
+    });
+
+    it('shows costs order file', () => {
+      return custom(CrProgressBar)
+        .withSession(basicSession)
+        .get()
+        .expect(httpStatus.OK)
+        .html($ => {
+          const rightHandSideMenu = $('.govuk-grid-column-one-third').html();
+
+          expect(rightHandSideMenu).to.include('Cost order');
+        });
+    });
+  });
+
+  describe('handle state DNPronounced and co respondent does not pays costs', () => {
+    const basicSession = {
+      caseState: 'DNPronounced',
+      originalPetition: {
+        costsClaimGranted: 'Yes',
+        whoPaysCosts: 'respondent',
+        decreeNisiGrantedDate: '2019-07-01T00:00:00.000+0000',
+        coRespondentAnswers: {
+          contactInfo: {
+            emailAddress: 'user@email.com'
+          },
+          aos: {
+            received: 'Yes',
+            letterHolderId: '755791',
+            dateReceived: '2019-02-22'
+          },
+          defendsDivorce: 'Yes',
+          answer: {
+            received: 'Yes'
+          }
+        },
+        d8: [
+          {
+            id: '401ab79e-34cb-4570-9f2f-4cf9357m4st3r',
+            fileName: 'costsOrder1554740111371638.pdf',
+            // eslint-disable-next-line max-len
+            fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560113f'
+          }
+        ]
+      }
+    };
+
+    it('shows correct content', () => {
+      content(CrProgressBar, basicSession, {
+        specificContent: [
+          'notDefending.heading',
+          'notDefending.info',
+          'helpHeading',
+          'helpContent',
+          'improveHeading',
+          'improveContent'
+        ]
+      });
+    });
+
+    it('shows costs order file', () => {
+      return custom(CrProgressBar)
+        .withSession(basicSession)
+        .get()
+        .expect(httpStatus.OK)
+        .html($ => {
+          const rightHandSideMenu = $('.govuk-grid-column-one-third').html();
+
+          expect(rightHandSideMenu).to.not.include('Cost order');
+        });
+    });
+  });
 
   describe('court address details', () => {
     const basicSession = {


### PR DESCRIPTION
# Description

[DIV-4892 - Co-Respondent landing page with Cost Order](https://tools.hmcts.net/jira/browse/DIV-4892)
 - Shows Costs order file if co-respondent paying
 - Shows specific content if state DNPronounced and co-respondent paying costs

[DIV-5123 - Co-Respondent landing page without Cost Order](https://tools.hmcts.net/jira/browse/DIV-5123)
 - Does not show any new content
 - Does not show costs order file

in addition it fixes some old styles missed in old gov.uk design updates