### PR TITLE
DIV-4698: use warnWithReq in ProgressBar.step.js

### DIFF
--- a/steps/respondent/progress-bar/ProgressBar.step.js
+++ b/steps/respondent/progress-bar/ProgressBar.step.js
@@ -125,7 +125,7 @@ class ProgressBar extends Interstitial {
       return this.progressStates.defendedDivorce;
     }
 
-    logger.errorWithReq(this.req, 'progress_bar_content', 'No valid case state for ProgressBar page', caseState);
+    logger.warnWithReq(this.req, 'progress_bar_content', 'No valid case state for ProgressBar page', caseState);
     return this.progressStates.other;
   }
 


### PR DESCRIPTION
# Description

Use warning log, not error log

Fixes # (issue)

https://tools.hmcts.net/jira/browse/DIV-4698

## Type of change

very easy change - use warning log instead of error log as it's misleading.
