### PR TITLE
DIV-5316: Fixed Error Message on Production and Fixed Error When ClaimsCostFrom…

### DIFF
--- a/steps/respondent/review-application/ReviewApplication.html
+++ b/steps/respondent/review-application/ReviewApplication.html
@@ -16,17 +16,17 @@
   {% endif %}
   <p class="govuk-body">
     {% if session.originalPetition.claimsCosts == "Yes" and session.originalPetition.financialOrder == "Yes" %}
-      {% if "respondent" in session.originalPetition.claimsCostsFrom and "correspondent" in session.originalPetition.claimsCostsFrom %}
+      {% if "respondent" in claimsCostsFromArray and "correspondent" in claimsCostsFromArray %}
         {{ content.costsPetitionerPayedByRespondentAndCorrespondent | safe }}
-      {% elseif "correspondent" in session.originalPetition.claimsCostsFrom  %}
+      {% elseif "correspondent" in claimsCostsFromArray  %}
         {{ content.costsPetitionerPayedByCorrespondent | safe }}
       {% else %}
         {{ content.costsPetitionerPayedByRespondent | safe }}
       {% endif %}
     {% elseif session.originalPetition.claimsCosts == "Yes" %}
-      {% if "respondent" in session.originalPetition.claimsCostsFrom and "correspondent" in session.originalPetition.claimsCostsFrom %}
+      {% if "respondent" in claimsCostsFromArray and "correspondent" in claimsCostsFromArray %}
         {{ content.costsPetitionerDivorceCostsByRespondentAndCorespondent | safe }}
-      {% elseif "correspondent" in session.originalPetition.claimsCostsFrom %}
+      {% elseif "correspondent" in claimsCostsFromArray %}
         {{ content.costsPetitionerDivorceCostsByCorespondent | safe }}
       {% else %}
         {{ content.costsPetitionerDivorceCostsByRespondent | safe }}
@@ -390,9 +390,9 @@
 
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0">{{ content.costOrder }}</h3>
   {% if session.originalPetition.claimsCosts == "Yes" %}
-    {% if "respondent" in session.originalPetition.claimsCostsFrom and "correspondent" in session.originalPetition.claimsCostsFrom %}
+    {% if "respondent" in claimsCostsFromArray and "correspondent" in claimsCostsFromArray %}
       <p class="govuk-body">{{ content.claimingCostsFromRespondentCoRespondent }}</p>
-    {% elseif "correspondent" in session.originalPetition.claimsCostsFrom %}
+    {% elseif "correspondent" in claimsCostsFromArray %}
       <p class="govuk-body">{{ content.claimingCostsFromCoRespondent }}</p>
     {% else %}
       <p class="govuk-body">{{ content.claimingCostsFromRespondent }}</p>

--- a/steps/respondent/review-application/ReviewApplication.step.js
+++ b/steps/respondent/review-application/ReviewApplication.step.js
@@ -50,6 +50,10 @@ class ReviewApplication extends Question {
     return parseBool(config.features.respSolicitorDetails);
   }
 
+  get claimsCostsFromArray() {
+    return this.req.session.originalPetition.claimsCostsFrom || [];
+  }
+
   get form() {
     const answers = [this.const.yes];
     const validAnswers = Joi.string()

--- a/test/unit/steps/respondent/reviewApplication.test.js
+++ b/test/unit/steps/respondent/reviewApplication.test.js
@@ -478,6 +478,21 @@ describe(modulePath, () => {
           session,
           { specificContent: ['costsPetitionerPayedByRespondent'] });
       });
+
+      it('when claims costs is null', () => {
+        const session = {
+          originalPetition: {
+            jurisdictionConnection: {},
+            claimsCosts: 'Yes',
+            financialOrder: 'Yes',
+            financialOrderFor: []
+          }
+        };
+        return content(
+          ReviewApplication,
+          session,
+          { specificContent: ['costsPetitionerPayedByRespondent'] });
+      });
     });
 
     context('claim costs only', () => {
@@ -518,6 +533,20 @@ describe(modulePath, () => {
             claimsCosts: 'Yes',
             financialOrder: 'No',
             claimsCostsFrom: []
+          }
+        };
+        return content(
+          ReviewApplication,
+          session,
+          { specificContent: ['costsPetitionerDivorceCostsByRespondent'] });
+      });
+
+      it('when claims costs is null', () => {
+        const session = {
+          originalPetition: {
+            jurisdictionConnection: {},
+            claimsCosts: 'Yes',
+            financialOrder: 'No'
           }
         };
         return content(

--- a/views/errors/content.html
+++ b/views/errors/content.html
@@ -10,7 +10,7 @@
 {% endif %}
 
 {% if error %}
-    {% if settings.env != 'prod' %}
+    {% if (settings.env != 'prod') and (settings.env != 'production') %}
     <div class="govuk-form-group--error">
         <label class="govuk-error-message">
             <span class="form-label-bold">Error Message</span>

--- a/views/errors/error.html
+++ b/views/errors/error.html
@@ -43,7 +43,7 @@
     {% endif %}
 
     {% if error %}
-        {% if settings.env != 'prod' %}
+        {% if (settings.env != 'prod') and (settings.env != 'production') %}
         <div class="govuk-form-group--error">
             <label class="govuk-error-message">
                 <span class="form-label-bold">Error Message</span>


### PR DESCRIPTION
… is Null

# Description

[DIV-5316 Error In Production Bug](https://tools.hmcts.net/jira/browse/DIV-5316)

There are two bugs here.
1. When claimCostsFrom is null or missing, Review-Application throws an error trying to parse it when claimsCost is YES. The fix is to default it to an empty array if not defined. This means in content, respondent will be displayed as the default claimFrom party.
2. NODE_ENV on PROD and AAT is actually 'production'. This fix does mean we will no longer see the error message on AAT either (as that environment is meant to be Prod-llke anyway). Errors can still be seen locally.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
