### PR TITLE
DIV-5552 - Unescape html entities before sending to COS and CCD

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "paths": "^0.1.1",
     "redis": "^2.8.0",
     "request": "^2.85.0",
-    "request-promise-native": "^1.0.5"
+    "request-promise-native": "^1.0.5",
+    "traverse": "^0.6.6"
   },
   "devDependencies": {
     "@hmcts/div-idam-test-harness": "^1.5.0",


### PR DESCRIPTION
# Description

[DIV-5552 Store special characters in CCD correctly](https://tools.hmcts.net/jira/browse/DIV-5552)

Essentially a reverse of the following sanitization: https://github.com/hmcts/one-per-page/blob/master/src/middleware/sanitizeRequestBody.js#L10

Possibly could update OPP instead.

This is just a draft PR to get some opinions.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
