### PR TITLE
Remove escaping html entities for Address lookup because the middlewa…

### DIFF
--- a/services/postcodeLookup.js
+++ b/services/postcodeLookup.js
@@ -1,9 +1,6 @@
 const config = require('config');
 const request = require('request-promise-native');
 const logger = require('services/logger').getLogger(__filename);
-const Entities = require('html-entities').AllHtmlEntities;
-
-const entities = new Entities();
 
 const cleanLine = function(line) {
   return line.replace(' null', ' ').replace('null ', ' ')
@@ -73,10 +70,8 @@ const buildConcatenatedAddress = function(address) { // eslint-disable-line comp
 const formatAddress = address => {
   const addressAsArray = buildConcatenatedAddress(address);
   const addressAsString = addressAsArray.join('\r\n');
-  // ensure any html entities are encoded i.e. & becomes &amp;
-  const addressEncoded = entities.encode(addressAsString);
 
-  return addressEncoded;
+  return addressAsString;
 };
 
 const postcodeLookup = postcode => {

--- a/test/unit/services/postcodeLookup.test.js
+++ b/test/unit/services/postcodeLookup.test.js
@@ -37,22 +37,6 @@ describe(modulePath, () => {
       expect(address).to.eql('1, WILBERFORCE ROAD\r\nLONDON\r\nN4 2SW');
     });
 
-    it('encodes html entities', () => {
-      const testAddress = {
-        DPA: {
-          BUILDING_NUMBER: '2 & 3',
-          THOROUGHFARE_NAME: 'WILBERFORCE ROAD',
-          POST_TOWN: 'LONDON',
-          POSTCODE: 'N4 2SW',
-          ADDRESS: '2, WILBERFORCE ROAD, LONDON, N4 2SW'
-        }
-      };
-
-      const address = postcodeLookupService.formatAddress(testAddress);
-
-      expect(address).to.eql('2 &amp; 3, WILBERFORCE ROAD\r\nLONDON\r\nN4 2SW');
-    });
-
     it('should format addresses correctly for EC1V 2PD', () => {
       const testAddress = {
         DPA: {


### PR DESCRIPTION
…re now handles it, in One Per Page version 5.3.0.

The bug is a result of this line in the RespondentSolicitorAddress step.js:
`selectedAddressValid.valid(postcodeList);`

Has an incompatibility with OPP 5.3.0.

It checks the currently selected address is one of the items in the postcode list or not. However, with the OPP middleware update, the address is now kept as & for example, and not &amp;
The bug occurred when the `entites.encode()` encodes each address and adds it to the whitelist, the whitelist is now `["Address &amp; Special Char"]` for example. Then the resulting value stored in temp session is `"Address & Special Char", which now no longer matches the whitelist, and the invalid / required error is shown.

This PR removes the HTML entity encoding because we are now keeping it as inputted, without modification.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local testing and unit testing. Pending QA testing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
