### PR TITLE
DIV-5747- Change Gov Panel to accessible Green for all service

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -8,6 +8,7 @@
 @import 'look-and-feel/related-items';
 @import 'look-and-feel/gov-uk-frontend-toolkit-backward-compatible';
 @import 'look-and-feel/confirmation-statement';
+@import 'look-and-feel/done-page';
 @import 'check-your-answers';
 
 .govuk-related-items {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@hmcts/ctsc-web-chat": "^0.3.9",
     "@hmcts/div-document-express-handler": "^1.1.0",
     "@hmcts/div-idam-express-middleware": "^6.4.0",
-    "@hmcts/look-and-feel": "^4.0.4",
+    "@hmcts/look-and-feel": "^4.0.5",
     "@hmcts/nodejs-healthcheck": "^1.5.1",
     "@hmcts/nodejs-logging": "^3.0.0",
     "@hmcts/one-per-page": "^5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,10 +301,10 @@
     webpack "^3.4.1"
     webpack-dev-middleware "^2.0.4"
 
-"@hmcts/look-and-feel@^4.0.4":
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/@hmcts/look-and-feel/-/look-and-feel-4.0.4.tgz#b817c453658b5cf72ec58e40a239a38541446b0a"
-  integrity sha512-OzQKUUfH+IXf2dZr7hoqXdscvsSfWe4ANynrtmFOsFCsASqKTBPoNE5Kt5qivDEO18HUeVdUoYL8KrkPNTY6XQ==
+"@hmcts/look-and-feel@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@hmcts/look-and-feel/-/look-and-feel-4.0.5.tgz#2065d248c1cdea098d63a51424347a6dcca154a2"
+  integrity sha512-gRui8wNvMa9F4qA4OAqszrCkCp3NuIk15U7l0HgfyzTa3wpdG86A2XFsgGDvSrXUEYEos/uxKDL/DdUi9XmfuA==
   dependencies:
     babel-core "^6.26.0"
     babel-loader "^7.1.2"
@@ -4535,7 +4535,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@>=2.2.3, https-proxy-agent@^2.2.1:
+https-proxy-agent@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz#fb6cd98ed5b9c35056b5a73cd01a8a721d7193d1"
   integrity sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==


### PR DESCRIPTION
# Description

[DIV-5747- Change Gov Panel to accessible Green for all services](https://tools.hmcts.net/jira/browse/DIV-5747)
 - Use latest look-and-feel ( which updates confirm panel colour )