### PR TITLE
Feature(TA-292): Add retrying for e2e test user setup, plus other crossbrowser test improvements

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -38,11 +38,8 @@ withNightlyPipeline("nodejs", product, component) {
   env.TEST_URL = params.URL_TO_TEST
   env.NODE_ENV= 'ci'
   env.test_environment = 'aat'
-
-  before('crossBrowserTest') {
-    env.FEATURE_RESP_EQUALITY = 'true'
-    env.FEATURE_CORESP_EQUALITY = 'true'
-  }
+  env.FEATURE_RESP_EQUALITY = 'true'
+  env.FEATURE_CORESP_EQUALITY = 'true'
 
   loadVaultSecrets(secrets)
   enableCrossBrowserTest()

--- a/config/default.yml
+++ b/config/default.yml
@@ -135,7 +135,7 @@ paths:
 tests:
   e2e:
     show: false
-    waitForTimeout: 10000
+    waitForTimeout: 15000
     waitForAction: 1000
     smartWait: 5000
     outputDir: './functional-output'

--- a/test/crossbrowser/supportedBrowsers.js
+++ b/test/crossbrowser/supportedBrowsers.js
@@ -26,7 +26,7 @@ const supportedBrowsers = {
   safari: {
     safari_mac_latest: {
       browserName: 'safari',
-      platformName: LATEST_MAC,
+      platformName: 'macOS 10.14',
       browserVersion: 'latest',
       'sauce:options': {
         name: 'MAC_SAFARI_LATEST_RESPONDENT',

--- a/test/crossbrowser/supportedBrowsers.js
+++ b/test/crossbrowser/supportedBrowsers.js
@@ -8,7 +8,7 @@ const supportedBrowsers = {
       platformName: LATEST_WINDOWS,
       browserVersion: 'latest',
       'sauce:options': {
-        name: 'IE11',
+        name: 'IE11_RESPONDENT',
         screenResolution: '1400x1050'
       }
     }
@@ -19,7 +19,7 @@ const supportedBrowsers = {
       platformName: LATEST_WINDOWS,
       browserVersion: 'latest',
       'sauce:options': {
-        name: 'Edge_Win10'
+        name: 'Edge_Win10_RESPONDENT'
       }
     }
   },
@@ -29,7 +29,7 @@ const supportedBrowsers = {
       platformName: LATEST_MAC,
       browserVersion: 'latest',
       'sauce:options': {
-        name: 'MAC_SAFARI_LATEST',
+        name: 'MAC_SAFARI_LATEST_RESPONDENT',
         seleniumVersion: '3.141.59',
         screenResolution: '1400x1050'
       }
@@ -41,7 +41,7 @@ const supportedBrowsers = {
       platformName: LATEST_WINDOWS,
       browserVersion: 'latest',
       'sauce:options': {
-        name: 'WIN_CHROME_LATEST'
+        name: 'WIN_CHROME_LATEST_RESPONDENT'
       }
     },
     chrome_mac_latest: {
@@ -49,7 +49,7 @@ const supportedBrowsers = {
       platformName: LATEST_MAC,
       browserVersion: 'latest',
       'sauce:options': {
-        name: 'MAC_CHROME_LATEST'
+        name: 'MAC_CHROME_LATEST_RESPONDENT'
       }
     }
   },
@@ -59,7 +59,7 @@ const supportedBrowsers = {
       platformName: LATEST_WINDOWS,
       browserVersion: 'latest',
       'sauce:options': {
-        name: 'WIN_FIREFOX_LATEST'
+        name: 'WIN_FIREFOX_LATEST_RESPONDENT'
       }
     },
     firefox_mac_latest: {
@@ -67,7 +67,7 @@ const supportedBrowsers = {
       platformName: LATEST_MAC,
       browserVersion: 'latest',
       'sauce:options': {
-        name: 'MAC_FIREFOX_LATEST'
+        name: 'MAC_FIREFOX_LATEST_RESPONDENT'
       }
     }
   }

--- a/test/e2e/codecept.conf.js
+++ b/test/e2e/codecept.conf.js
@@ -18,7 +18,7 @@ if (proxyByPass) {
 
 exports.config = {
   tests: './paths/**/*.js',
-  output: config.tests.e2e.outputDir,
+  output: `${process.cwd()}/functional-output`,
   helpers: {
     Puppeteer: {
       url: config.tests.e2e.url || config.node.baseUrl,

--- a/test/e2e/helpers/JSWait.js
+++ b/test/e2e/helpers/JSWait.js
@@ -1,12 +1,12 @@
 class JSWait extends codecept_helper { // eslint-disable-line camelcase
-  _beforeStep(step) {
+  async _beforeStep(step) {
     const helper = this.helpers.WebDriver || this.helpers.Puppeteer;
 
     // Wait for content to load before checking URL
     if (step.name === 'seeCurrentUrlEquals' || step.name === 'seeInCurrentUrl') {
-      return helper.waitForElement('body', 30);
+      await helper.waitForElement('body', 30);
     }
-    return Promise.resolve;
+    return step;
   }
 
   async navByClick(text, locator) {

--- a/test/e2e/helpers/JSWait.js
+++ b/test/e2e/helpers/JSWait.js
@@ -1,10 +1,10 @@
 class JSWait extends codecept_helper { // eslint-disable-line camelcase
-  async _beforeStep(step) {
+  _beforeStep(step) {
     const helper = this.helpers.WebDriver || this.helpers.Puppeteer;
 
     // Wait for content to load before checking URL
     if (step.name === 'seeCurrentUrlEquals' || step.name === 'seeInCurrentUrl') {
-      await helper.waitForElement('body', 30);
+      return helper.waitForElement('body', 30);
     }
     return step;
   }

--- a/test/e2e/helpers/JSWait.js
+++ b/test/e2e/helpers/JSWait.js
@@ -13,13 +13,18 @@ class JSWait extends codecept_helper { // eslint-disable-line camelcase
     const helper = this.helpers.WebDriver || this.helpers.Puppeteer;
     const helperIsPuppeteer = this.helpers.Puppeteer;
 
-    await helper.click(text, locator);
+    // eslint-disable-next-line no-console
+    console.log(`Starting navByClick(${text}, ${locator})...`);
+    const result = await helper.click(text, locator);
 
     if (helperIsPuppeteer) {
       await helper.page.waitForNavigation({ waitUntil: 'domcontentloaded' });
     } else {
       await helper.wait(2);
     }
+    // eslint-disable-next-line no-console
+    console.log('navByClick() result:', result);
+    return result;
   }
 
   async amOnLoadedPage(url, language = 'en') {

--- a/test/e2e/helpers/JSWait.js
+++ b/test/e2e/helpers/JSWait.js
@@ -1,19 +1,19 @@
 class JSWait extends codecept_helper { // eslint-disable-line camelcase
-  _beforeStep(step) {
+  async _beforeStep(step) {
     const helper = this.helpers.WebDriver || this.helpers.Puppeteer;
 
     // Wait for content to load before checking URL
     if (step.name === 'seeCurrentUrlEquals' || step.name === 'seeInCurrentUrl') {
-      return helper.waitForElement('body', 30);
+      await helper.waitForElement('body', 30);
     }
-    return Promise.resolve();
+    return step;
   }
 
   async navByClick(text, locator) {
     const helper = this.helpers.WebDriver || this.helpers.Puppeteer;
     const helperIsPuppeteer = this.helpers.Puppeteer;
 
-    helper.click(text, locator);
+    await helper.click(text, locator);
 
     if (helperIsPuppeteer) {
       await helper.page.waitForNavigation({ waitUntil: 'domcontentloaded' });

--- a/test/e2e/helpers/JSWait.js
+++ b/test/e2e/helpers/JSWait.js
@@ -13,18 +13,13 @@ class JSWait extends codecept_helper { // eslint-disable-line camelcase
     const helper = this.helpers.WebDriver || this.helpers.Puppeteer;
     const helperIsPuppeteer = this.helpers.Puppeteer;
 
-    // eslint-disable-next-line no-console
-    console.log(`Starting navByClick(${text}, ${locator})...`);
-    const result = await helper.click(text, locator);
+    helper.click(text, locator);
 
     if (helperIsPuppeteer) {
       await helper.page.waitForNavigation({ waitUntil: 'domcontentloaded' });
     } else {
       await helper.wait(2);
     }
-    // eslint-disable-next-line no-console
-    console.log('navByClick() result:', result);
-    return result;
   }
 
   async amOnLoadedPage(url, language = 'en') {

--- a/test/e2e/helpers/JSWait.js
+++ b/test/e2e/helpers/JSWait.js
@@ -1,12 +1,12 @@
 class JSWait extends codecept_helper { // eslint-disable-line camelcase
-  async _beforeStep(step) {
+  _beforeStep(step) {
     const helper = this.helpers.WebDriver || this.helpers.Puppeteer;
 
     // Wait for content to load before checking URL
     if (step.name === 'seeCurrentUrlEquals' || step.name === 'seeInCurrentUrl') {
-      await helper.waitForElement('body', 30);
+      return helper.waitForElement('body', 30);
     }
-    return step;
+    return Promise.resolve;
   }
 
   async navByClick(text, locator) {

--- a/test/e2e/helpers/SauceLabsBrowserHelper.js
+++ b/test/e2e/helpers/SauceLabsBrowserHelper.js
@@ -1,0 +1,16 @@
+// eslint-disable-next-line camelcase
+const Helper = codecept_helper;
+
+class SauceLabsBrowserHelper extends Helper {
+  async _before() {
+    const webdriver = this.helpers.WebDriver;
+    if (webdriver) {
+      if (webdriver.config.browser === 'internet explorer') {
+        console.log('Increasing IE11 browser window size'); /* eslint-disable-line no-console */
+        await webdriver.browser.setWindowSize(1280, 960);
+      }
+    }
+  }
+}
+
+module.exports = SauceLabsBrowserHelper;

--- a/test/e2e/helpers/idamHelper.js
+++ b/test/e2e/helpers/idamHelper.js
@@ -62,9 +62,11 @@ class IdamHelper extends Helper {
   }
 
   _after() {
+    logger.infoWithReq(null, 'removing_idam_user', 'Removing IDAM test user...');
+    const testEmail = idamArgs.testEmail;
     idamExpressTestHarness.removeUser(idamArgs, config.tests.e2e.proxy)
       .then(() => {
-        logger.infoWithReq(null, 'idam_user_removed', 'Removed IDAM test user', idamArgs.testEmail);
+        logger.infoWithReq(null, 'idam_user_removed', 'Removed IDAM test user', testEmail);
       })
       .catch(error => {
         logger.warnWithReq(null, 'idam_error', 'Unable to remove IDAM test user', error.message);

--- a/test/e2e/pages/co-respondent/crAdmitAdultery.step.js
+++ b/test/e2e/pages/co-respondent/crAdmitAdultery.step.js
@@ -3,6 +3,7 @@ const content = require('steps/co-respondent/cr-admit-adultery/CrAdmitAdultery.c
 
 function seeCrAdmitAdulteryPage(language = 'en') {
   const I = this;
+  I.waitInUrl(AdmitAdulteryPage.path);
   I.seeCurrentUrlEquals(AdmitAdulteryPage.path);
   I.waitForText(content[language].title);
 }

--- a/test/e2e/pages/co-respondent/crAgreeToPayCosts.step.js
+++ b/test/e2e/pages/co-respondent/crAgreeToPayCosts.step.js
@@ -3,6 +3,7 @@ const content = require('steps/co-respondent/cr-agree-to-pay-costs/CrAgreeToPayC
 
 function seeCrAgreeToPayCostsPage(language = 'en') {
   const I = this;
+  I.waitInUrl(CrAgreeToPayCosts.path);
   I.seeCurrentUrlEquals(CrAgreeToPayCosts.path);
   I.waitForText(content[language].title);
 }

--- a/test/e2e/pages/co-respondent/crCheckYourAnswers.step.js
+++ b/test/e2e/pages/co-respondent/crCheckYourAnswers.step.js
@@ -3,7 +3,7 @@ const content = require('steps/co-respondent/cr-check-your-answers/CrCheckYourAn
 
 function seeCrCheckYourAnswersPage(language = 'en') {
   const I = this;
-
+  I.waitInUrl(crCheckYourAnswers.path);
   I.seeCurrentUrlEquals(crCheckYourAnswers.path);
   I.waitForText(content[language].title);
 }

--- a/test/e2e/pages/co-respondent/crChooseAResponse.step.js
+++ b/test/e2e/pages/co-respondent/crChooseAResponse.step.js
@@ -3,6 +3,7 @@ const content = require('steps/co-respondent/cr-choose-a-response/CrChooseARespo
 
 function seeCrChooseAResponsePage(language = 'en') {
   const I = this;
+  I.waitInUrl(CrChooseAResponsePage.path);
   I.seeCurrentUrlEquals(CrChooseAResponsePage.path);
   I.waitForText(content[language].title);
 }

--- a/test/e2e/pages/co-respondent/crContactDetails.step.js
+++ b/test/e2e/pages/co-respondent/crContactDetails.step.js
@@ -3,7 +3,7 @@ const content = require('steps/co-respondent/cr-contact-details/CrContactDetails
 
 function seeCrContactDetailsPage(language = 'en') {
   const I = this;
-
+  I.waitInUrl(CrContactDetails.path);
   I.seeCurrentUrlEquals(CrContactDetails.path);
   I.waitForText(content[language].title);
 }

--- a/test/e2e/pages/co-respondent/crRespond.step.js
+++ b/test/e2e/pages/co-respondent/crRespond.step.js
@@ -3,6 +3,7 @@ const content = require('steps/co-respondent/cr-respond/CrRespond.content');
 
 function seeCrRespondPage(language = 'en') {
   const I = this;
+  I.waitInUrl(CrRespondPage.path);
   I.seeCurrentUrlEquals(CrRespondPage.path);
   I.waitForText(content[language].title);
 }

--- a/test/e2e/pages/co-respondent/crReviewApplication.step.js
+++ b/test/e2e/pages/co-respondent/crReviewApplication.step.js
@@ -3,6 +3,7 @@ const content = require('steps/co-respondent/cr-review-application/CrReviewAppli
 
 function seeCrReviewApplicationPage(language = 'en') {
   const I = this;
+  I.waitInUrl(CrReviewApplicationPage.path);
   I.seeCurrentUrlEquals(CrReviewApplicationPage.path);
   I.waitForText(content[language].title);
 }

--- a/test/e2e/pages/common/captureCaseIdAndPin.step.js
+++ b/test/e2e/pages/common/captureCaseIdAndPin.step.js
@@ -7,7 +7,7 @@ function seeCaptureCaseAndPinPage(language = 'en') {
   const I = this;
   I.waitInUrl(CaptureCaseAndPinPage.path, 30);
   I.seeCurrentUrlEquals(CaptureCaseAndPinPage.path);
-  I.waitForText(content[language].title, 5);
+  I.waitForText(content[language].title);
 }
 
 function fillInReferenceNumberAndPinCode(referenceNumber, pinCode) {

--- a/test/e2e/pages/common/equality.js
+++ b/test/e2e/pages/common/equality.js
@@ -2,12 +2,12 @@ const path = 'https://pcq.aat.platform.hmcts.net/start-page';
 
 function seeEqualityPage(language = 'en') {
   const I = this;
-  I.waitInUrl(path, 15);
-  I.seeCurrentUrlEquals(path);
+  I.waitInUrl(path);
+  I.seeInCurrentUrl(path);
   if (language === 'en') {
-    I.waitForText('Equality and diversity questions', 5);
+    I.waitForText('Equality and diversity questions');
   } else {
-    I.waitForText('Cwestiynau am Gydraddoldeb ac Amrywiaeth', 5);
+    I.waitForText('Cwestiynau am Gydraddoldeb ac Amrywiaeth');
   }
 }
 

--- a/test/e2e/pages/common/idam.step.js
+++ b/test/e2e/pages/common/idam.step.js
@@ -14,6 +14,7 @@ function login(language = 'en') {
   const I = this;
 
   if (config.features.idam) {
+    I.waitInUrl('/login?');
     I.seeInCurrentUrl('/login?');
     I.fillField('username', idamConfigHelper.getTestEmail());
     I.fillField('password', idamConfigHelper.getTestPassword());

--- a/test/e2e/pages/respondent/agreeToPayCosts.step.js
+++ b/test/e2e/pages/respondent/agreeToPayCosts.step.js
@@ -3,9 +3,9 @@ const content = require('steps/respondent/agree-to-pay-costs/AgreeToPayCosts.con
 
 function seeAgreeToPayCostsPage(language = 'en') {
   const I = this;
-  I.waitInUrl(AgreeToPayCosts.path, 15);
+  I.waitInUrl(AgreeToPayCosts.path);
   I.seeCurrentUrlEquals(AgreeToPayCosts.path);
-  I.waitForText(content[language].title, 2);
+  I.waitForText(content[language].title);
 }
 
 function chooseAgreeToPay(language = 'en') {

--- a/test/e2e/pages/respondent/checkYourAnswers.step.js
+++ b/test/e2e/pages/respondent/checkYourAnswers.step.js
@@ -5,9 +5,9 @@ const { parseBool } = require('@hmcts/one-per-page');
 
 function seeCheckYourAnswersPage(language = 'en') {
   const I = this;
-  I.waitInUrl(CheckYourAnswersPage.path, 15);
+  I.waitInUrl(CheckYourAnswersPage.path);
   I.seeCurrentUrlEquals(CheckYourAnswersPage.path);
-  I.waitForText(content[language].title, 5);
+  I.waitForText(content[language].title);
 }
 
 function confirmInformationIsTrue(language = 'en') {

--- a/test/e2e/pages/respondent/chooseAResponse.step.js
+++ b/test/e2e/pages/respondent/chooseAResponse.step.js
@@ -4,9 +4,9 @@ const content = require('steps/respondent/choose-a-response/ChooseAResponse.cont
 function seeChooseAResponsePage(language = 'en') {
   const I = this;
 
-  I.waitInUrl(ChooseAResponsePage.path, 15);
+  I.waitInUrl(ChooseAResponsePage.path);
   I.seeCurrentUrlEquals(ChooseAResponsePage.path);
-  I.waitForText(content[language].title, 2);
+  I.waitForText(content[language].title);
 }
 
 function chooseToProceedWithDivorce(language = 'en') {

--- a/test/e2e/pages/respondent/consent2yrSeparation.js
+++ b/test/e2e/pages/respondent/consent2yrSeparation.js
@@ -4,6 +4,7 @@ const content = require('steps/respondent/consent-decree/ConsentDecree.content')
 function seeConsentDecreePage(language = 'en') {
   const I = this;
 
+  I.waitInUrl(ConsentDecree.path);
   I.seeCurrentUrlEquals(ConsentDecree.path);
   I.waitForText(content[language].title);
 }

--- a/test/e2e/pages/respondent/contactDetails.step.js
+++ b/test/e2e/pages/respondent/contactDetails.step.js
@@ -3,9 +3,9 @@ const content = require('steps/respondent/contact-details/ContactDetails.content
 
 function seeContactDetailsPage(language = 'en') {
   const I = this;
-  I.waitInUrl(ContactDetails.path, 15);
+  I.waitInUrl(ContactDetails.path);
   I.seeCurrentUrlEquals(ContactDetails.path);
-  I.waitForText(content[language].title, 5);
+  I.waitForText(content[language].title);
 }
 
 function consentToSendingNotifications(language = 'en') {

--- a/test/e2e/pages/respondent/done.step.js
+++ b/test/e2e/pages/respondent/done.step.js
@@ -3,9 +3,9 @@ const content = require('steps/respondent/done/Done.content');
 
 function seeDonePage(language = 'en') {
   const I = this;
-  I.waitInUrl(DonePage.path, 15);
-  I.seeCurrentUrlEquals(DonePage.path);
-  I.waitForText(content[language].responseSent, 2);
+  I.waitInUrl(DonePage.path);
+  I.seeInCurrentUrl(DonePage.path);
+  I.waitForText(content[language].responseSent);
 }
 
 module.exports = { seeDonePage };

--- a/test/e2e/pages/respondent/financialSituation.js
+++ b/test/e2e/pages/respondent/financialSituation.js
@@ -3,7 +3,7 @@ const content = require('steps/respondent/financial-situation/FinancialSituation
 
 function seeFinancialSituationPage(language = 'en') {
   const I = this;
-
+  I.waitInUrl(FinancialSituation.path);
   I.seeCurrentUrlEquals(FinancialSituation.path);
   I.waitForText(content[language].title);
 }

--- a/test/e2e/pages/respondent/hasSolicitor.step.js
+++ b/test/e2e/pages/respondent/hasSolicitor.step.js
@@ -3,7 +3,7 @@ const content = require('steps/respondent/solicitor-representation/SolicitorRepr
 
 function seeSolicitorRepPage(language = 'en') {
   const I = this;
-  I.waitInUrl(SolicitorRep.path, 15);
+  I.waitInUrl(SolicitorRep.path);
   I.seeCurrentUrlEquals(SolicitorRep.path);
   I.waitForText(content[language].title);
 }

--- a/test/e2e/pages/respondent/jurisdiction.step.js
+++ b/test/e2e/pages/respondent/jurisdiction.step.js
@@ -4,13 +4,14 @@ const content = require('steps/respondent/jurisdiction/Jurisdiction.content');
 function seeJurisdictionPage(language = 'en') {
   const I = this;
 
-  I.waitInUrl(Jurisdiction.path, 15);
+  I.waitInUrl(Jurisdiction.path);
   I.seeCurrentUrlEquals(Jurisdiction.path);
-  I.waitForText(content[language].title, 5);
+  I.waitForText(content[language].title);
 }
 
 function chooseAgreeToJurisdiction(language = 'en') {
   this.click(content[language].fields.agree.heading);
+  this.wait(2);
 }
 
 module.exports = {

--- a/test/e2e/pages/respondent/languagePreference.step.js
+++ b/test/e2e/pages/respondent/languagePreference.step.js
@@ -4,9 +4,9 @@ const content = require('steps/respondent/language-preference/LanguagePreference
 function seeLanguagePreferencePage(language = 'en') {
   const I = this;
 
-  I.waitInUrl(languagePreference.path, 15);
+  I.waitInUrl(languagePreference.path);
   I.seeCurrentUrlEquals(languagePreference.path);
-  I.waitForText(content[language].title, 5);
+  I.waitForText(content[language].title);
 }
 
 function chooseBilingualApplication(language = 'en') {

--- a/test/e2e/pages/respondent/legalProceedings.step.js
+++ b/test/e2e/pages/respondent/legalProceedings.step.js
@@ -4,9 +4,9 @@ const content = require('steps/respondent/legal-proceedings/LegalProceedings.con
 function seeLegalProceedingPage(language = 'en') {
   const I = this;
 
-  I.waitInUrl(LegalProceedingPage.path, 15);
+  I.waitInUrl(LegalProceedingPage.path);
   I.seeCurrentUrlEquals(LegalProceedingPage.path);
-  I.waitForText(content[language].title, 5);
+  I.waitForText(content[language].title);
 }
 
 function chooseNoLegalProceedings(language = 'en') {

--- a/test/e2e/pages/respondent/respond.step.js
+++ b/test/e2e/pages/respondent/respond.step.js
@@ -3,9 +3,9 @@ const content = require('steps/respondent/respond/Respond.content');
 
 function seeRespondPage(language = 'en') {
   const I = this;
-  I.waitInUrl(RespondPage.path, 15);
+  I.waitInUrl(RespondPage.path);
+  I.waitForText(content[language].title);
   I.seeCurrentUrlEquals(RespondPage.path);
-  I.waitForText(content[language].title, 2);
 }
 
 function seeDocumentsForDownload() {

--- a/test/e2e/pages/respondent/reviewApplication.step.js
+++ b/test/e2e/pages/respondent/reviewApplication.step.js
@@ -3,9 +3,9 @@ const content = require('steps/respondent/review-application/ReviewApplication.c
 
 function seeReviewApplicationPage(language = 'en') {
   const I = this;
-  I.waitInUrl(ReviewApplicationPage.path, 15);
+  I.waitInUrl(ReviewApplicationPage.path);
   I.seeCurrentUrlEquals(ReviewApplicationPage.path);
-  I.waitForText(content[language].title, 5);
+  I.waitForText(content[language].title);
 }
 
 function acknowledgeApplication(language = 'en') {

--- a/test/e2e/paths/co-respondent/adulteryJourney.js
+++ b/test/e2e/paths/co-respondent/adulteryJourney.js
@@ -7,11 +7,11 @@ const languages = ['en', 'cy'];
 
 const runTests = (language = 'en') => {
   Scenario(`@Pipeline Proceed to adultery admission screen and admit adultery - ${language}`, async I => {
-    await I.createAUser();
-    I.createAosCaseForUser(adulteryDivorceSession, true);
+    await I.retry(2).createAUser();
+    I.retry(2).createAosCaseForUser(adulteryDivorceSession, true);
     await I.amOnLoadedPage('/', language);
 
-    await I.createAUser();
+    await I.retry(2).createAUser();
     I.login(language);
     I.seeCaptureCaseAndPinPage(language);
     I.fillInReferenceNumberAndPinCode();

--- a/test/e2e/paths/co-respondent/adulteryJourney.js
+++ b/test/e2e/paths/co-respondent/adulteryJourney.js
@@ -53,6 +53,7 @@ const runTests = (language = 'en') => {
     I.seeCrCheckYourAnswersPage(language);
     I.confirmInformationIsTrueCr(language);
     I.submitApplicationCr(language);
+    I.seeDonePage(language);
     I.see('EZ12D91234');
   })
     .retry(2);

--- a/test/e2e/paths/respondent/2yrSeparationHappyPath-en-cy.js
+++ b/test/e2e/paths/respondent/2yrSeparationHappyPath-en-cy.js
@@ -7,11 +7,11 @@ const languages = ['en', 'cy'];
 
 const runTests = (language = 'en') => {
   Scenario(`@Pipeline 2+ Years Separation Journey, Proceed divorce - ${language}`, async I => {
-    await I.createAUser();
-    I.createAosCaseForUser(twoPlusYearsDivorceSession);
+    await I.retry(2).createAUser();
+    I.retry(2).createAosCaseForUser(twoPlusYearsDivorceSession);
     await I.amOnLoadedPage('/', language);
 
-    await I.createAUser();
+    await I.retry(2).createAUser();
     I.login(language);
     I.seeCaptureCaseAndPinPage(language);
     I.fillInReferenceNumberAndPinCode();

--- a/test/e2e/paths/respondent/2yrSeparationHappyPath-en-cy.js
+++ b/test/e2e/paths/respondent/2yrSeparationHappyPath-en-cy.js
@@ -41,7 +41,8 @@ const runTests = (language = 'en') => {
 
     I.seeJurisdictionPage(language);
     I.chooseAgreeToJurisdiction(language);
-    I.click(content[language].continue);
+    I.scrollPageToBottom();
+    I.navByClick(content[language].continue);
 
     I.seeLegalProceedingPage(language);
     I.chooseNoLegalProceedings(language);

--- a/test/e2e/paths/respondent/5yrSeparationHappyPath-en-cy.js
+++ b/test/e2e/paths/respondent/5yrSeparationHappyPath-en-cy.js
@@ -7,11 +7,11 @@ const languages = ['en', 'cy'];
 
 const runTests = (language = 'en') => {
   Scenario(`@Pipeline 5+ Years Separation Journey, Proceed divorce - ${language}`, async I => {
-    await I.createAUser();
-    I.createAosCaseForUser(fivePlusYearsDivorceSession);
+    await I.retry(2).createAUser();
+    I.retry(2).createAosCaseForUser(fivePlusYearsDivorceSession);
     await I.amOnLoadedPage('/', language);
 
-    await I.createAUser();
+    await I.retry(2).createAUser();
     I.login(language);
     I.seeCaptureCaseAndPinPage(language);
     I.fillInReferenceNumberAndPinCode();

--- a/test/e2e/paths/respondent/5yrSeparationHappyPath-en-cy.js
+++ b/test/e2e/paths/respondent/5yrSeparationHappyPath-en-cy.js
@@ -41,6 +41,7 @@ const runTests = (language = 'en') => {
 
     I.seeJurisdictionPage(language);
     I.chooseAgreeToJurisdiction(language);
+    I.scrollPageToBottom();
     I.click(content[language].continue);
 
     I.seeLegalProceedingPage(language);

--- a/test/e2e/paths/respondent/behaviourHappyPath-en-cy.js
+++ b/test/e2e/paths/respondent/behaviourHappyPath-en-cy.js
@@ -48,6 +48,7 @@ const runTests = (language = 'en') => {
 
     I.seeJurisdictionPage(language);
     I.chooseAgreeToJurisdiction(language);
+    I.scrollPageToBottom();
     if (config.tests.e2e.addWaitForCrossBrowser) {
       I.click(contentJurisdiction[language].fields.disagree.heading);
       I.fillField('jurisdiction.reason', 'what to try something diff for crossbrowser');

--- a/test/e2e/paths/respondent/behaviourHappyPath-en-cy.js
+++ b/test/e2e/paths/respondent/behaviourHappyPath-en-cy.js
@@ -9,11 +9,11 @@ const languages = ['en', 'cy'];
 
 const runTests = (language = 'en') => {
   Scenario(`@Pipeline Behaviour Journey, Proceed divorce with linked user - ${language}`, async I => {
-    await I.createAUser();
-    I.createAosCaseForUser(basicDivorceSession);
+    await I.retry(2).createAUser();
+    I.retry(2).createAosCaseForUser(basicDivorceSession);
     await I.amOnLoadedPage('/', language);
 
-    await I.createAUser();
+    await I.retry(2).createAUser();
     I.login(language);
     I.seeCaptureCaseAndPinPage(language);
     I.fillInReferenceNumberAndPinCode();

--- a/test/e2e/paths/respondent/desertionJourneyHappyPath-en-cy.js
+++ b/test/e2e/paths/respondent/desertionJourneyHappyPath-en-cy.js
@@ -36,6 +36,7 @@ const runTests = (language = 'en') => {
 
     I.seeJurisdictionPage(language);
     I.chooseAgreeToJurisdiction(language);
+    I.scrollPageToBottom();
     I.click(content[language].continue);
 
     I.seeLegalProceedingPage(language);

--- a/test/e2e/paths/respondent/desertionJourneyHappyPath-en-cy.js
+++ b/test/e2e/paths/respondent/desertionJourneyHappyPath-en-cy.js
@@ -7,11 +7,11 @@ const languages = ['en', 'cy'];
 
 const runTests = (language = 'en') => {
   Scenario(`@Pipeline Proceed with divorce with desertion without agreement case - ${language}`, async I => {
-    await I.createAUser();
-    I.createAosCaseForUser(desertionSession);
+    await I.retry(2).createAUser();
+    I.retry(2).createAosCaseForUser(desertionSession);
     await I.amOnLoadedPage('/', language);
 
-    await I.createAUser();
+    await I.retry(2).createAUser();
     I.login(language);
     I.seeCaptureCaseAndPinPage(language);
     I.fillInReferenceNumberAndPinCode();

--- a/test/e2e/saucelabs.conf.js
+++ b/test/e2e/saucelabs.conf.js
@@ -73,6 +73,15 @@ const setupConfig = {
       }
     }
   },
+  plugins: {
+    retryFailedStep: {
+      enabled: true,
+      retries: 2
+    },
+    autoDelay: {
+      enabled: true
+    }
+  },
   multiple: {
     microsoftIE11: {
       browsers: getBrowserConfig('microsoftIE11')

--- a/test/e2e/saucelabs.conf.js
+++ b/test/e2e/saucelabs.conf.js
@@ -50,7 +50,8 @@ const setupConfig = {
     SauceLabsReportingHelper: { require: './helpers/sauceLabsReportingHelper.js' },
     JSWait: { require: './helpers/JSWait.js' },
     IdamHelper: { require: './helpers/idamHelper.js' },
-    CaseHelper: { require: './helpers/caseHelper.js' }
+    CaseHelper: { require: './helpers/caseHelper.js' },
+    SauceLabsBrowserHelper: { require: './helpers/SauceLabsBrowserHelper.js' }
   },
   include: { I: './pages/steps.js' },
   mocha: {


### PR DESCRIPTION
# Description

This change includes:
- retrying for both IDAM test user creation and CCD case creation
- better waiting for items to load and be visible to browser
- fix to solve an unhandled promise that was causing issues with CodeceptJS
- browser window resize for IE11, as it opens very small on Saucelabs initially
- rename of jobs for easier differentiation when debugging in Saucelabs

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally many times for each browser, but only with English language due to an ongoing issue with language settings when on the PCQ page (issue raised https://tools.hmcts.net/jira/browse/DIV-6652). Also testing via Nightly build.

**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
