### PR TITLE
Feature(TA-77): Run crossbrowser tests nightly (2)

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -42,7 +42,7 @@ withNightlyPipeline("nodejs", product, component) {
   env.FEATURE_CORESP_EQUALITY = 'true'
 
   loadVaultSecrets(secrets)
-//  enableCrossBrowserTest()
+  enableCrossBrowserTest()
   enableSecurityScan()
   enableFullFunctionalTest()
 

--- a/bin/run-crossbrowser-tests.sh
+++ b/bin/run-crossbrowser-tests.sh
@@ -11,7 +11,6 @@ EXIT_STATUS=0
 BROWSER_GROUP=chrome yarn test-crossbrowser-e2e || EXIT_STATUS=$?
 BROWSER_GROUP=firefox yarn test-crossbrowser-e2e || EXIT_STATUS=$?
 BROWSER_GROUP=safari yarn test-crossbrowser-e2e || EXIT_STATUS=$?
-BROWSER_GROUP=microsoftIE11 yarn test-crossbrowser-e2e || EXIT_STATUS=$?
-BROWSER_GROUP=microsoftEdge yarn test-crossbrowser-e2e || EXIT_STATUS=$?
+BROWSER_GROUP=microsoft yarn test-crossbrowser-e2e || EXIT_STATUS=$?
 echo EXIT_STATUS: $EXIT_STATUS
 exit $EXIT_STATUS

--- a/test/crossbrowser/supportedBrowsers.js
+++ b/test/crossbrowser/supportedBrowsers.js
@@ -2,7 +2,7 @@ const LATEST_MAC = 'macOS 10.15';
 const LATEST_WINDOWS = 'Windows 10';
 
 const supportedBrowsers = {
-  microsoftIE11: {
+  microsoft: {
     ie11: {
       browserName: 'internet explorer',
       platformName: LATEST_WINDOWS,
@@ -11,9 +11,7 @@ const supportedBrowsers = {
         name: 'IE11_RESPONDENT',
         screenResolution: '1400x1050'
       }
-    }
-  },
-  microsoftEdge: {
+    },
     edge: {
       browserName: 'MicrosoftEdge',
       platformName: LATEST_WINDOWS,

--- a/test/e2e/helpers/JSWait.js
+++ b/test/e2e/helpers/JSWait.js
@@ -13,11 +13,11 @@ class JSWait extends codecept_helper { // eslint-disable-line camelcase
     const helper = this.helpers.WebDriver || this.helpers.Puppeteer;
     const helperIsPuppeteer = this.helpers.Puppeteer;
 
-    helper.click(text, locator);
-
     if (helperIsPuppeteer) {
+      helper.click(text, locator);
       await helper.page.waitForNavigation({ waitUntil: 'domcontentloaded' });
     } else {
+      await helper.click(text, locator);
       await helper.wait(2);
     }
   }

--- a/test/e2e/pages/co-respondent/crChooseAResponse.step.js
+++ b/test/e2e/pages/co-respondent/crChooseAResponse.step.js
@@ -9,7 +9,7 @@ function seeCrChooseAResponsePage(language = 'en') {
 }
 
 function chooseCrToProceedWithDivorce(language = 'en') {
-  this.click(content[language].fields.proceed.heading);
+  this.checkOption(content[language].fields.proceed.heading);
 }
 
 function chooseCrToDefendAgainstDivorce() {

--- a/test/e2e/pages/co-respondent/crReviewApplication.step.js
+++ b/test/e2e/pages/co-respondent/crReviewApplication.step.js
@@ -5,7 +5,7 @@ function seeCrReviewApplicationPage(language = 'en') {
   const I = this;
   I.waitInUrl(CrReviewApplicationPage.path);
   I.seeCurrentUrlEquals(CrReviewApplicationPage.path);
-  I.waitForText(content[language].title);
+  I.waitForText(content[language].issued);
 }
 
 function acknowledgeApplicationCr(language = 'en') {

--- a/test/e2e/pages/common/captureCaseIdAndPin.step.js
+++ b/test/e2e/pages/common/captureCaseIdAndPin.step.js
@@ -5,7 +5,7 @@ const caseConfigHelper = require('test/e2e//helpers/caseConfigHelper.js');
 
 function seeCaptureCaseAndPinPage(language = 'en') {
   const I = this;
-  I.waitInUrl(CaptureCaseAndPinPage.path, 30);
+  I.waitInUrl(CaptureCaseAndPinPage.path, 45);
   I.seeCurrentUrlEquals(CaptureCaseAndPinPage.path);
   I.waitForText(content[language].title);
 }

--- a/test/e2e/pages/common/equality.js
+++ b/test/e2e/pages/common/equality.js
@@ -1,4 +1,5 @@
 const path = 'https://pcq.aat.platform.hmcts.net/start-page';
+const config = require('config');
 
 function seeEqualityPage(language = 'en') {
   const I = this;
@@ -10,7 +11,9 @@ function seeEqualityPage(language = 'en') {
 }
 
 function completePCQs(language = 'en') {
-  if (language === 'en') {
+  // PCQ pages only display in English on AAT (e.g. running nightly),
+  // see bug: https://tools.hmcts.net/jira/browse/RPET-632
+  if (language === 'en' || config.tests.e2e.addWaitForCrossBrowser) {
     this.click('I don\'t want to answer these questions');
   } else {
     this.click('Dydw i ddim eisiau ateb y cwestiynau hyn');

--- a/test/e2e/paths/co-respondent/adulteryJourney.js
+++ b/test/e2e/paths/co-respondent/adulteryJourney.js
@@ -17,7 +17,7 @@ const runTests = (language = 'en') => {
     I.fillInReferenceNumberAndPinCode();
     I.navByClick(content[language].continue);
     if (config.tests.e2e.addWaitForCrossBrowser) {
-      I.wait(30);
+      I.wait(3);
     }
 
     I.seeCrRespondPage(language);

--- a/test/e2e/paths/respondent/2yrSeparationHappyPath-en-cy.js
+++ b/test/e2e/paths/respondent/2yrSeparationHappyPath-en-cy.js
@@ -17,7 +17,7 @@ const runTests = (language = 'en') => {
     I.fillInReferenceNumberAndPinCode();
     I.navByClick(content[language].continue);
     if (config.tests.e2e.addWaitForCrossBrowser) {
-      I.wait(30);
+      I.wait(3);
     }
     I.seeRespondPage(language);
     I.click(content[language].continue);

--- a/test/e2e/paths/respondent/5yrSeparationHappyPath-en-cy.js
+++ b/test/e2e/paths/respondent/5yrSeparationHappyPath-en-cy.js
@@ -17,7 +17,7 @@ const runTests = (language = 'en') => {
     I.fillInReferenceNumberAndPinCode();
     I.navByClick(content[language].continue);
     if (config.tests.e2e.addWaitForCrossBrowser) {
-      I.wait(30);
+      I.wait(3);
     }
     I.seeRespondPage(language);
     I.click(content[language].continue);

--- a/test/e2e/paths/respondent/behaviourHappyPath-en-cy.js
+++ b/test/e2e/paths/respondent/behaviourHappyPath-en-cy.js
@@ -19,7 +19,7 @@ const runTests = (language = 'en') => {
     I.fillInReferenceNumberAndPinCode();
     I.navByClick(content[language].continue);
     if (config.tests.e2e.addWaitForCrossBrowser) {
-      I.wait(30);
+      I.wait(3);
     }
     I.seeRespondPage(language);
     I.navByClick(content[language].continue);
@@ -30,7 +30,7 @@ const runTests = (language = 'en') => {
     I.navByClick(content[language].continue);
 
     if (config.tests.e2e.addWaitForCrossBrowser) {
-      I.wait(30);
+      I.wait(3);
       if (parseBool(config.features.respSolicitorDetails)) {
         I.seeSolicitorRepPage(language);
         I.selectNoSolicitor(language);

--- a/test/e2e/paths/respondent/desertionJourneyHappyPath-en-cy.js
+++ b/test/e2e/paths/respondent/desertionJourneyHappyPath-en-cy.js
@@ -17,7 +17,7 @@ const runTests = (language = 'en') => {
     I.fillInReferenceNumberAndPinCode();
     I.navByClick(content[language].continue);
     if (config.tests.e2e.addWaitForCrossBrowser) {
-      I.wait(30);
+      I.wait(3);
     }
     I.seeRespondPage(language);
     I.click(content[language].continue);

--- a/test/e2e/saucelabs.conf.js
+++ b/test/e2e/saucelabs.conf.js
@@ -84,11 +84,8 @@ const setupConfig = {
     }
   },
   multiple: {
-    microsoftIE11: {
-      browsers: getBrowserConfig('microsoftIE11')
-    },
-    microsoftEdge: {
-      browsers: getBrowserConfig('microsoftEdge')
+    microsoft: {
+      browsers: getBrowserConfig('microsoft')
     },
     chrome: {
       browsers: getBrowserConfig('chrome')


### PR DESCRIPTION
# Description

This change:
- turns back on the crossbrowser tests in the nightly pipeline
- fixes an e2e test wait where the Welsh content has a NBSP character that browsers handle differently, and can cause test flakiness
- adds a workaround to `completePCQs()` for the current bug (https://tools.hmcts.net/jira/browse/RPET-632) where PCQ pages always display in English on AAT regardless of the language of the test
- reduces crossbrowser-specific waits now that steps wait better for page content

Fixes # https://tools.hmcts.net/jira/browse/TA-77

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested locally for both Puppeteer functional and Webdriver crossbrowser tests, and in the PR pipeline.


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
