### PR TITLE
DIV-6654: Map general referral states on Respondent apps

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -91,6 +91,7 @@ paths:
   entry: /entry
   end: /end
   termsAndConditions: /terms-and-conditions
+  divorceApplicationProcessing: /divorce-application-processing
   cookiesPolicy: /cookie
   privacyPolicy: /privacy-policy
   authenticated: /authenticated
@@ -177,7 +178,7 @@ respRespondableStates: [
   'AwaitingDWPResponse'
 ]
 
-dnCaseStates: [
+applicationProcessingCaseStates: [
   'AwaitingGeneralReferralPayment',
   'GeneralConsiderationComplete'
 ]

--- a/core/utils/petitionHelper.js
+++ b/core/utils/petitionHelper.js
@@ -1,11 +1,10 @@
 const config = require('config');
-const logger = require('services/logger').getLogger(__filename);
 
 const authTokenString = '__auth-token';
-const statesToRedirectToDn = config.dnCaseStates;
+const applicationProcessingCases = config.applicationProcessingCaseStates;
 
-const isStateToRedirectToDn = caseState => {
-  return statesToRedirectToDn.includes(caseState);
+const isApplicationProcessing = caseState => {
+  return applicationProcessingCases.includes(caseState);
 };
 
 const getDnRedirectUrl = req => {
@@ -22,16 +21,8 @@ const getDaRedirectUrl = req => {
   return redirectUrl;
 };
 
-const redirectToDn = (req, res, caseState) => {
-  const redirectUrl = getDnRedirectUrl(req);
-  logger.infoWithReq(req, 'redirect_to_dn', `case state is ${caseState}, redirecting to DN`);
-  logger.infoWithReq(req, redirectUrl);
-  return res.redirect(redirectUrl);
-};
-
 module.exports = {
-  isStateToRedirectToDn,
-  redirectToDn,
+  isApplicationProcessing,
   getDnRedirectUrl,
   getDaRedirectUrl
 };

--- a/middleware/petitionMiddleware.js
+++ b/middleware/petitionMiddleware.js
@@ -3,10 +3,11 @@ const config = require('config');
 const CaptureCaseAndPin = require('steps/capture-case-and-pin/CaptureCaseAndPin.step');
 const ProgressBar = require('steps/respondent/progress-bar/ProgressBar.step');
 const crProgressBar = require('steps/co-respondent/cr-progress-bar/CrProgressBar.step');
+const DivorceApplicationProcessing = require('steps/divorce-application-processing/DivorceApplicationProcessing.step');
 const logger = require('services/logger').getLogger(__filename);
 const crRespond = require('steps/co-respondent/cr-respond/CrRespond.step');
 const httpStatus = require('http-status-codes');
-const { isStateToRedirectToDn, redirectToDn, getDaRedirectUrl } = require('core/utils/petitionHelper');
+const { isApplicationProcessing, getDaRedirectUrl } = require('core/utils/petitionHelper');
 
 function storePetitionInSession(req, response) {
   req.session.referenceNumber = response.body.caseId;
@@ -60,8 +61,9 @@ const loadMiniPetition = (req, res, next) => {
         storePetitionInSession(req, response);
 
         const caseState = response.body.state;
-        if (isStateToRedirectToDn(caseState)) {
-          return redirectToDn(req, res, caseState);
+        if (isApplicationProcessing(caseState)) {
+          logger.infoWithReq(req, 'divorce_application_processing', `Case state is ${caseState}, redirecting to Divorce Application Processing detail page`);
+          return res.redirect(DivorceApplicationProcessing.path);
         }
 
         const originalPetition = req.session.originalPetition;

--- a/steps/divorce-application-processing/DivorceApplicationProcessing.content.json
+++ b/steps/divorce-application-processing/DivorceApplicationProcessing.content.json
@@ -1,0 +1,22 @@
+{
+  "en": {
+    "title": "Your divorce application is being processed.",
+    "info": "You can contact us about your divorce application.",
+    "contactTitle": "Contact us",
+    "email": "Email",
+    "phone": "Phone",
+    "divorceEmail": "divorcecase@justice.gov.uk",
+    "openTimes": "(Monday to Friday, 8am to 8pm, Saturday 8am to 2pm)",
+    "phoneNumber" : "0300 303 0642"
+  },
+  "cy": {
+    "title": "Mae eich cais am ysgariad yn cael ei brosesu.",
+    "info": "Gallwch gysylltu â ni i drafod eich cais am ysgariad.",
+    "contactTitle": "Cysylltu â ni",
+    "email": "E-bost",
+    "phone": "Ffôn",
+    "divorceEmail": "ymholiadaucymraeg@justice.gov.uk",
+    "openTimes": "(Dydd Llun i ddydd Gwener, 8.30am – 5pm)",
+    "phoneNumber" : "0300 303 5171"
+  }
+}

--- a/steps/divorce-application-processing/DivorceApplicationProcessing.html
+++ b/steps/divorce-application-processing/DivorceApplicationProcessing.html
@@ -1,0 +1,20 @@
+{% extends "page.njk" %}
+
+{% block back %} {% endblock %}
+
+{% set title %}
+{{ content.title }}
+{% endset %}
+
+{% block main_content %}
+<p class="govuk-body">{{ content.info }}</p>
+<h2 class="govuk-heading-m">{{ content.contactTitle }}</h2>
+<p class="govuk-body">
+  <strong>{{ content.email }}: </strong>
+  <a class="govuk-link" href="mailto:{{ content.divorceEmail }}" aria-label="{{ content.email }}, this link opens a new email.">{{ content.divorceEmail | safe }}</a><br>
+</p>
+<p class="govuk-body">
+  <strong>{{ content.phone }}: </strong>
+  {{ content.phoneNumber | safe }} {{ content.openTimes | safe}}<br>
+</p>
+{% endblock %}

--- a/steps/divorce-application-processing/DivorceApplicationProcessing.step.js
+++ b/steps/divorce-application-processing/DivorceApplicationProcessing.step.js
@@ -1,0 +1,22 @@
+const { Page } = require('@hmcts/one-per-page');
+const config = require('config');
+const checkWelshToggle = require('middleware/checkWelshToggle');
+
+class DivorceApplicationProcessing extends Page {
+  static get ignorePa11yWarnings() {
+    return ['WCAG2AA.Principle1.Guideline1_3.1_3_1.H48'];
+  }
+
+  static get path() {
+    return config.paths.divorceApplicationProcessing;
+  }
+
+  get middleware() {
+    return [
+      ...super.middleware,
+      checkWelshToggle
+    ];
+  }
+}
+
+module.exports = DivorceApplicationProcessing;

--- a/test/unit/core/utils/petitionerHelper.test.js
+++ b/test/unit/core/utils/petitionerHelper.test.js
@@ -1,9 +1,8 @@
 const modulePath = 'middleware/petitionMiddleware';
 const config = require('config');
-const { sinon, expect, itParam } = require('@hmcts/one-per-page-test-suite');
+const { expect, itParam } = require('@hmcts/one-per-page-test-suite');
 const {
-  isStateToRedirectToDn,
-  redirectToDn,
+  isApplicationProcessing,
   getDnRedirectUrl,
   getDaRedirectUrl
 } = require('core/utils/petitionHelper');
@@ -18,14 +17,14 @@ const req = {
 };
 
 describe(modulePath, () => {
-  itParam('should return true if state is to be handled on DN', config.dnCaseStates, (done, validState) => {
-    expect(isStateToRedirectToDn(validState)).to.be.true;
+  itParam('should return true if state is to be handled on DN', config.applicationProcessingCaseStates, (done, validState) => {
+    expect(isApplicationProcessing(validState)).to.be.true;
     done();
   });
 
   it('should return false if state is not to be handled on DN', () => {
     const validState = 'DNPronounced';
-    expect(isStateToRedirectToDn(validState)).to.be.false;
+    expect(isApplicationProcessing(validState)).to.be.false;
   });
 
   it('should return expected DN redirect url', () => {
@@ -42,16 +41,5 @@ describe(modulePath, () => {
     expect(expectedUrl).to.contain(config.services.daFrontend.url);
     expect(expectedUrl).to.contain(config.services.daFrontend.landing);
     expect(expectedUrl).to.contain(authTokenString);
-  });
-
-  it('should fire redirect url to DN', () => {
-    const res = {
-      redirect: sinon.spy()
-    };
-    const dnRedirectUrl = getDnRedirectUrl(req);
-
-    redirectToDn(req, res, 'caseState');
-
-    expect(res.redirect.withArgs(dnRedirectUrl).calledOnce).to.be.true;
   });
 });

--- a/test/unit/middleware/petitionMiddleware.test.js
+++ b/test/unit/middleware/petitionMiddleware.test.js
@@ -2,7 +2,6 @@ const modulePath = 'middleware/petitionMiddleware';
 const config = require('config');
 const { sinon, expect, itParam } = require('@hmcts/one-per-page-test-suite');
 const { loadMiniPetition: petitionMiddleware } = require(modulePath);
-const { getDnRedirectUrl } = require('core/utils/petitionHelper');
 const caseOrchestration = require('services/caseOrchestration');
 // eslint-disable-next-line max-len
 const completedMock = require(
@@ -19,6 +18,7 @@ const CaptureCaseAndPin = require('steps/capture-case-and-pin/CaptureCaseAndPin.
 const ProgressBar = require('steps/respondent/progress-bar/ProgressBar.step');
 const crProgressBar = require('steps/co-respondent/cr-progress-bar/CrProgressBar.step');
 const crRespond = require('steps/co-respondent/cr-respond/CrRespond.step');
+const DivorceApplicationProcessing = require('steps/divorce-application-processing/DivorceApplicationProcessing.step');
 const httpStatus = require('http-status-codes');
 
 const authTokenString = '__auth-token';
@@ -407,7 +407,7 @@ describe(modulePath, () => {
   });
 
   describe('Redirections to DN app', () => {
-    const stateToRedirectToDn = config.dnCaseStates;
+    const stateToRedirectToDn = config.applicationProcessingCaseStates;
 
     itParam('should redirect respondent to DN when state is ${value}', stateToRedirectToDn, (done, state) => {
       // given
@@ -434,12 +434,10 @@ describe(modulePath, () => {
           body: mockRespResponse
         });
 
-      const dnRedirectUrl = getDnRedirectUrl(req);
-
       // when
       petitionMiddleware(req, res, next)
         .then(() => {
-          expect(res.redirect.withArgs(dnRedirectUrl).calledOnce).to.be.true;
+          expect(res.redirect.withArgs(DivorceApplicationProcessing.path).calledOnce).to.be.true;
         })
         .then(done, done);
     });
@@ -469,12 +467,10 @@ describe(modulePath, () => {
           body: mockCoRespResponse
         });
 
-      const dnRedirectUrl = getDnRedirectUrl(req);
-
       // when
       petitionMiddleware(req, res, next)
         .then(() => {
-          expect(res.redirect.withArgs(dnRedirectUrl).calledOnce).to.be.true;
+          expect(res.redirect.withArgs(DivorceApplicationProcessing.path).calledOnce).to.be.true;
         })
         .then(done, done);
     });

--- a/test/unit/steps/divorceApplicationProcessing.test.js
+++ b/test/unit/steps/divorceApplicationProcessing.test.js
@@ -1,0 +1,37 @@
+const modulePath = 'steps/terms-and-conditions/TermsAndConditions.step';
+
+const DivorceApplicationProcessing = require(modulePath);
+const { middleware, content } = require('@hmcts/one-per-page-test-suite');
+
+describe(modulePath, () => {
+  it('has no middleware', () => {
+    return middleware.hasMiddleware(DivorceApplicationProcessing, []);
+  });
+
+  describe('values', () => {
+    it('displays correct details', () => {
+      const ignoreContent = [
+        'continue',
+        'webChatTitle',
+        'chatDown',
+        'chatWithAnAgent',
+        'noAgentsAvailable',
+        'allAgentsBusy',
+        'chatClosed',
+        'chatAlreadyOpen',
+        'chatOpeningHours',
+        'serviceName',
+        'backLink',
+        'signIn',
+        'signOut',
+        'languageToggle',
+        'thereWasAProblem',
+        'change',
+        'husband',
+        'wife'
+      ];
+
+      return content(DivorceApplicationProcessing, {}, { ignoreContent });
+    });
+  });
+});


### PR DESCRIPTION
# Description

Implementing a landing page for RFE when case is either `AwaitingReferralPaymemt` or `GeneralComsiderationComplete`. Original implementation was to reuse similar existing page on DN but the authtoken from RFE does not seem to work when trying to use it to retrieve case data on DN.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
